### PR TITLE
Use the Travis cache to persist the composer cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,12 +10,16 @@ matrix:
   allow_failures:
     - php: hhvm
     - php: hhvm-nightly
+    
+cache:
+  directories:
+    - $HOME/.composer/cache
 
 script:
  - vendor/bin/phpunit --coverage-clover=coverage.clover
 
 before_script:
- - composer install --no-interaction --prefer-source --dev
+ - composer install --no-interaction
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar


### PR DESCRIPTION
As your builds are running on the Docker-based infrastructure (which is now the default for any new repo), the caching feature is available. This allows to cache downloaded dist archives between builds.
I removed the ``--prefer-source`` option so that cachable archives are used for stable deps (i.e. all deps currently).
I also removed the deprecated ``--dev`` option as it has no effect other than displaying a message saying it should not be used anymore (it is a no-op option since approximately 2 years)
