### PR TITLE
Run PHPUnit in verbose mode on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - php: hhvm-nightly
 
 script:
- - vendor/bin/phpunit --coverage-clover=coverage.clover
+ - vendor/bin/phpunit --coverage-clover=coverage.clover -v
 
 before_script:
  - composer install --no-interaction --prefer-source --dev


### PR DESCRIPTION
This allows to see why tests are marked as skipped or risky (you have risky tests currently).