### PR TITLE
Add an array typehint for the Compound constructor

### DIFF
--- a/src/Types/Compound.php
+++ b/src/Types/Compound.php
@@ -31,7 +31,7 @@ final class Compound implements Type
      *
      * @param Type[] $types
      */
-    public function __construct($types)
+    public function __construct(array $types)
     {
         foreach ($types as $type) {
             if (!$type instanceof Type) {


### PR DESCRIPTION
The code only accepts arrays to be valid. So the argument can be typehinted