### PR TITLE
Ignore any tokens within classes when looking for namespaces

### DIFF
--- a/src/Types/ContextFactory.php
+++ b/src/Types/ContextFactory.php
@@ -70,6 +70,26 @@ final class ContextFactory
                 case T_NAMESPACE:
                     $currentNamespace = $this->parseNamespace($tokens);
                     break;
+                case T_CLASS:
+                    // Fast-forward the iterator through the class so that any
+                    // T_USE tokens found within are skipped - these are not
+                    // valid namespace use statements so should be ignored.
+                    $braceLevel = 0;
+                    $firstBraceFound = false;
+                    while ($tokens->valid() && ($braceLevel > 0 || !$firstBraceFound)) {
+                        if ($tokens->current() === '{') {
+                            if (!$firstBraceFound) {
+                                $firstBraceFound = true;
+                            }
+                            $braceLevel++;
+                        }
+
+                        if ($tokens->current() === '}') {
+                            $braceLevel--;
+                        }
+                        $tokens->next();
+                    }
+                    break;
                 case T_USE:
                     if ($currentNamespace === $namespace) {
                         $useStatements = array_merge($useStatements, $this->parseUseStatement($tokens));

--- a/tests/unit/Types/ContextFactoryTest.php
+++ b/tests/unit/Types/ContextFactoryTest.php
@@ -88,6 +88,26 @@ namespace phpDocumentor\Reflection\Types {
 
             $this->assertSame($expected, $context->getNamespaceAliases());
         }
+
+        public function testTraitUseIsNotDetectedAsNamespaceUse()
+        {
+            $fixture = new ContextFactory();
+
+            $php = "<?php
+                namespace Foo;
+
+                trait FooTrait {}
+
+                class FooClass {
+                    use FooTrait;
+                }
+            ";
+
+            $fixture = new ContextFactory();
+            $context = $fixture->createForNamespace('Foo', $php);
+
+            $this->assertSame([], $context->getNamespaceAliases());
+        }
     }
 }
 


### PR DESCRIPTION
This should resolve issue #8 

Basically, this proposed solution looks for classes, looks for the first opening brace, then keeps iterating until the same-level closing brace is found, then we continue.

I may've missed a use-case with this, but I think on the surface this should work - happy for any feedback given :)