### PR TITLE
Improvements for #9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,7 @@ before_script:
  - composer install --no-interaction
 
 after_script:
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
+  - if [ $TRAVIS_PHP_VERSION = '5.6' ]; then wget https://scrutinizer-ci.com/ocular.phar; php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
 
 notifications:
   irc: "irc.freenode.org#phpdocumentor"

--- a/src/Types/ContextFactory.php
+++ b/src/Types/ContextFactory.php
@@ -77,7 +77,9 @@ final class ContextFactory
                     $braceLevel = 0;
                     $firstBraceFound = false;
                     while ($tokens->valid() && ($braceLevel > 0 || !$firstBraceFound)) {
-                        if ($tokens->current() === '{') {
+                        if ($tokens->current() === '{'
+                            || $tokens->current()[0] === T_CURLY_OPEN
+                            || $tokens->current()[0] === T_DOLLAR_OPEN_CURLY_BRACES) {
                             if (!$firstBraceFound) {
                                 $firstBraceFound = true;
                             }

--- a/tests/unit/Types/ContextFactoryTest.php
+++ b/tests/unit/Types/ContextFactoryTest.php
@@ -89,6 +89,10 @@ namespace phpDocumentor\Reflection\Types {
             $this->assertSame($expected, $context->getNamespaceAliases());
         }
 
+        /**
+         * @covers ::createForNamespace
+         * @uses phpDocumentor\Reflection\Types\Context
+         */
         public function testTraitUseIsNotDetectedAsNamespaceUse()
         {
             $fixture = new ContextFactory();

--- a/tests/unit/Types/ContextFactoryTest.php
+++ b/tests/unit/Types/ContextFactoryTest.php
@@ -95,8 +95,6 @@ namespace phpDocumentor\Reflection\Types {
          */
         public function testTraitUseIsNotDetectedAsNamespaceUse()
         {
-            $fixture = new ContextFactory();
-
             $php = "<?php
                 namespace Foo;
 

--- a/tests/unit/Types/ContextFactoryTest.php
+++ b/tests/unit/Types/ContextFactoryTest.php
@@ -110,6 +110,45 @@ namespace phpDocumentor\Reflection\Types {
 
             $this->assertSame([], $context->getNamespaceAliases());
         }
+
+        /**
+         * @covers ::createForNamespace
+         * @uses phpDocumentor\Reflection\Types\Context
+         */
+        public function testAllOpeningBracesAreCheckedWhenSearchingForEndOfClass()
+        {
+            $php = '<?php
+                namespace Foo;
+
+                trait FooTrait {}
+                trait BarTrait {}
+
+                class FooClass {
+                    use FooTrait;
+
+                    public function bar()
+                    {
+                        echo "{$baz}";
+                        echo "${baz}";
+                    }
+                }
+
+                class BarClass {
+                    use BarTrait;
+
+                    public function bar()
+                    {
+                        echo "{$baz}";
+                        echo "${baz}";
+                    }
+                }
+            ';
+
+            $fixture = new ContextFactory();
+            $context = $fixture->createForNamespace('Foo', $php);
+
+            $this->assertSame([], $context->getNamespaceAliases());
+        }
     }
 }
 


### PR DESCRIPTION
After some discussions in #9, this PR provides improvements to the former:

* Travis build should not be broken
* Check for `T_CURLY_OPEN` and `T_DOLLAR_OPEN_CURLY_BRACES` (these were indeed silently failing previously) and adds test
* Adds `@covers` annotation for `testTraitUseIsNotDetectedAsNamespaceUse`
* Removes pointless LOC from the same