### PR TITLE
Fix file_get_contents warning in ContextFactory

### DIFF
--- a/src/Types/ContextFactory.php
+++ b/src/Types/ContextFactory.php
@@ -37,8 +37,6 @@ final class ContextFactory
      * @see Context for more information on Contexts.
      *
      * @return Context
-     *
-     * @throws \InvalidArgumentException
      */
     public function createFromReflector(\Reflector $reflector)
     {
@@ -47,11 +45,13 @@ final class ContextFactory
         }
 
         $fileName = $reflector->getFileName();
-        if (!$fileName) {
-            throw new \InvalidArgumentException('There is no file name associated with this reflector.');
+        $namespace = $reflector->getNamespaceName();
+
+        if (file_exists($fileName)) {
+            return $this->createForNamespace($namespace, file_get_contents($fileName));
         }
 
-        return $this->createForNamespace($reflector->getNamespaceName(), file_get_contents($fileName));
+        return new Context($namespace, []);
     }
 
     /**

--- a/src/Types/ContextFactory.php
+++ b/src/Types/ContextFactory.php
@@ -37,13 +37,19 @@ final class ContextFactory
      * @see Context for more information on Contexts.
      *
      * @return Context
+     *
+     * @throws \InvalidArgumentException
      */
     public function createFromReflector(\Reflector $reflector)
     {
         if (method_exists($reflector, 'getDeclaringClass')) {
             $reflector = $reflector->getDeclaringClass();
         }
+
         $fileName = $reflector->getFileName();
+        if (!$fileName) {
+            throw new \InvalidArgumentException('There is no file name associated with this reflector.');
+        }
 
         return $this->createForNamespace($reflector->getNamespaceName(), file_get_contents($fileName));
     }

--- a/tests/unit/Types/ContextFactoryTest.php
+++ b/tests/unit/Types/ContextFactoryTest.php
@@ -149,6 +149,16 @@ namespace phpDocumentor\Reflection\Types {
 
             $this->assertSame([], $context->getNamespaceAliases());
         }
+
+        /**
+         * @expectedException \InvalidArgumentException
+         * @covers ::createFromReflector
+         */
+        public function testThrowExceptionWhenEmptyFileName()
+        {
+            $fixture = new ContextFactory();
+            $fixture->createFromReflector(new \ReflectionClass('stdClass'));
+        }
     }
 }
 

--- a/tests/unit/Types/ContextFactoryTest.php
+++ b/tests/unit/Types/ContextFactoryTest.php
@@ -151,13 +151,33 @@ namespace phpDocumentor\Reflection\Types {
         }
 
         /**
-         * @expectedException \InvalidArgumentException
          * @covers ::createFromReflector
          */
-        public function testThrowExceptionWhenEmptyFileName()
+        public function testEmptyFileName()
         {
             $fixture = new ContextFactory();
-            $fixture->createFromReflector(new \ReflectionClass('stdClass'));
+            $context = $fixture->createFromReflector(new \ReflectionClass('stdClass'));
+
+            $this->assertSame([], $context->getNamespaceAliases());
+        }
+
+        /**
+         * @covers ::createFromReflector
+         */
+        public function testEvalDClass()
+        {
+            eval(<<<PHP
+namespace Foo;
+
+class Bar
+{
+}
+PHP
+);
+            $fixture = new ContextFactory();
+            $context = $fixture->createFromReflector(new \ReflectionClass('Foo\Bar'));
+
+            $this->assertSame([], $context->getNamespaceAliases());
         }
     }
 }


### PR DESCRIPTION
Currently, a warning like `warning: file_get_contents(): Filename cannot be empty in [...]/prophecy/vendor/phpdocumentor/type-resolver/src/Types/ContextFactory.php line 48` is generated by the library if there is no filename associated with the reflector passed to `ContextFactory`.

This PR fix this.