### PR TITLE
Added basic support for PSR-5 <> type notation.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "psr-4": {"phpDocumentor\\Reflection\\": ["tests/unit"]}
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.2",
+        "phpunit/phpunit": "^5.2||^4.8.24",
         "mockery/mockery": "^0.9.4"
     },
     "extra": {

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -22,6 +22,12 @@ final class TypeResolver
     /** @var string Definition of the ARRAY operator for types */
     const OPERATOR_ARRAY = '[]';
 
+    /** @var string Definition of the GENERIC OPEN operator for types */
+    const OPERATOR_OPEN_GENERIC = '<';
+
+    /** @var string Definition of the GENERIC CLOSE operator for types */
+    const OPERATOR_CLOSE_GENERIC = '>';
+
     /** @var string Definition of the NAMESPACE operator in PHP */
     const OPERATOR_NAMESPACE = '\\';
 
@@ -106,6 +112,8 @@ final class TypeResolver
                 return $this->resolveCompoundType($type, $context);
             case $this->isTypedArray($type):
                 return $this->resolveTypedArray($type, $context);
+            case $this->isGenericType($type):
+                return $this->resolveGenericType($type, $context);
             case $this->isFqsen($type):
                 return $this->resolveTypedObject($type);
             case $this->isPartialStructuralElementName($type):
@@ -156,6 +164,18 @@ final class TypeResolver
     private function isTypedArray($type)
     {
         return substr($type, -2) === self::OPERATOR_ARRAY;
+    }
+
+    /**
+     * Detects whether the given type represents an generic type.
+     *
+     * @param string $type A relative or absolute type as defined in the phpDocumentor documentation.
+     *
+     * @return bool
+     */
+    private function isGenericType($type)
+    {
+        return substr($type, -1) === self::OPERATOR_CLOSE_GENERIC;
     }
 
     /**
@@ -217,6 +237,34 @@ final class TypeResolver
     private function resolveTypedArray($type, Context $context)
     {
         return new Array_($this->resolve(substr($type, 0, -2), $context));
+    }
+
+    /**
+     * Resolves the given generic type (i.e. `string[]`) into an Array object with the right types set.
+     *
+     * @param string $type
+     * @param Context $context
+     *
+     * @return Array_|Object_
+     */
+    private function resolveGenericType($type, Context $context)
+    {
+        $regex = '/^([^<]+)<(?:([^,>]+),)*([^,>]+)>$/';
+        preg_match($regex, $type, $matches);
+        $class = $matches[1];
+        $args = array_splice($matches, $matches[2]? 2 : 3 );
+        if (strtolower($class) === 'array') {
+            if (count($args) > 1) {
+                $key   = $this->resolve(trim($args[0]), $context);
+                $value =  $this->resolve(trim($args[1]), $context);
+                return new Array_($value, $key);
+            } else {
+                $value =  $this->resolve(trim($args[0]), $context);
+                return new Array_($value);
+            }
+        } else {
+            return new Object_($this->fqsenResolver->resolve($class, $context));
+        }
     }
 
     /**

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -31,6 +31,7 @@ class TypeResolverTest extends \PHPUnit_Framework_TestCase
      * @covers ::resolve
      * @covers ::<private>
      *
+     * @uses phpDocumentor\Reflection\Types\Compound
      * @uses phpDocumentor\Reflection\Types\Context
      * @uses phpDocumentor\Reflection\Types\Array_
      * @uses phpDocumentor\Reflection\Types\Object_
@@ -124,6 +125,7 @@ class TypeResolverTest extends \PHPUnit_Framework_TestCase
      * @covers ::resolve
      * @covers ::<private>
      *
+     * @uses phpDocumentor\Reflection\Types\Compound
      * @uses phpDocumentor\Reflection\Types\Context
      * @uses phpDocumentor\Reflection\Types\Array_
      * @uses phpDocumentor\Reflection\Types\String_
@@ -146,6 +148,68 @@ class TypeResolverTest extends \PHPUnit_Framework_TestCase
      * @covers ::resolve
      * @covers ::<private>
      *
+     * @uses phpDocumentor\Reflection\Types\Array_
+     * @uses phpDocumentor\Reflection\Types\Compound
+     * @uses phpDocumentor\Reflection\Types\Context
+     * @uses phpDocumentor\Reflection\Types\Integer
+     * @uses phpDocumentor\Reflection\Types\String_
+     */
+    public function testResolvingGenericArrays()
+    {
+        $fixture = new TypeResolver();
+
+        /** @var Array_ $resolvedType */
+        $resolvedType = $fixture->resolve('array<int>', new Context(''));
+
+        $this->assertInstanceOf('phpDocumentor\Reflection\Types\Array_', $resolvedType);
+        $this->assertSame('int[]', (string)$resolvedType);
+        $this->assertInstanceOf('phpDocumentor\Reflection\Types\Compound', $resolvedType->getKeyType());
+        $this->assertInstanceOf('phpDocumentor\Reflection\Types\Integer', $resolvedType->getValueType());
+
+        /** @var Array_ $resolvedType */
+        $resolvedType = $fixture->resolve('array<int, int[]>', new Context(''));
+
+        $this->assertInstanceOf('phpDocumentor\Reflection\Types\Array_', $resolvedType);
+        $this->assertSame('int[][]', (string)$resolvedType);
+        $this->assertInstanceOf('phpDocumentor\Reflection\Types\Integer', $resolvedType->getKeyType());
+        $this->assertInstanceOf('phpDocumentor\Reflection\Types\Array_', $resolvedType->getValueType());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::resolve
+     * @covers ::<private>
+     *
+     * @uses phpDocumentor\Reflection\FqsenResolver
+     * @uses phpDocumentor\Reflection\Types\Array_
+     * @uses phpDocumentor\Reflection\Types\Compound
+     * @uses phpDocumentor\Reflection\Types\Context
+     * @uses phpDocumentor\Reflection\Types\Integer
+     * @uses phpDocumentor\Reflection\Types\Object_
+     */
+    public function testResolvingGenericObjects()
+    {
+        $fixture = new TypeResolver();
+
+        /** @var Array_ $resolvedType */
+        $resolvedType = $fixture->resolve('Object<int>', new Context(''));
+
+        $this->assertInstanceOf('phpDocumentor\Reflection\Types\Object_', $resolvedType);
+        $this->assertSame('\Object', (string)$resolvedType);
+
+        /** @var Array_ $resolvedType */
+        $resolvedType = $fixture->resolve('Object<int, Object, Object, void>', new Context(''));
+
+        $this->assertInstanceOf('phpDocumentor\Reflection\Types\Object_', $resolvedType);
+        $this->assertSame('\Object', (string)$resolvedType);
+
+    }
+    /**
+     * @covers ::__construct
+     * @covers ::resolve
+     * @covers ::<private>
+     * 
+     * @uses phpDocumentor\Reflection\Types\Compound
      * @uses phpDocumentor\Reflection\Types\Context
      * @uses phpDocumentor\Reflection\Types\Array_
      * @uses phpDocumentor\Reflection\Types\String_

--- a/tests/unit/Types/ContextFactoryTest.php
+++ b/tests/unit/Types/ContextFactoryTest.php
@@ -152,6 +152,8 @@ namespace phpDocumentor\Reflection\Types {
 
         /**
          * @covers ::createFromReflector
+         *
+         * @uses phpDocumentor\Reflection\Types\Context
          */
         public function testEmptyFileName()
         {
@@ -163,6 +165,8 @@ namespace phpDocumentor\Reflection\Types {
 
         /**
          * @covers ::createFromReflector
+         *
+         * @uses phpDocumentor\Reflection\Types\Context
          */
         public function testEvalDClass()
         {


### PR DESCRIPTION
Since the notation is not final, all this patch
does is accept the values and provide the information
using the same object already available.

`array<int>` will be parsed as if there was `int[]`.
`array<int, int>` will set the array key type but
not do much extra.

`Object<this,will,be,ignored>` will return an `Object_`
type of the right type, no way is provided to get
the inner type at this moment.

Ran `phpunit --coverage-text` and fixed the missing uses, to check that I did not decrease coverage.
