### PR TITLE
Rename Void to Void_ since it is a reserved keyword in PHP7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,14 @@ php:
   - 5.6
   - 7.0
   - hhvm
+  - nightly
 
 matrix:
   allow_failures:
-    - php: hhvm
-    
+    - php:
+      - hhvm
+      - nightly
+
 cache:
   directories:
     - $HOME/.composer/cache

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "psr-4": {"phpDocumentor\\Reflection\\": ["tests/unit"]}
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.2",
+        "phpunit/phpunit": "^5.2||^4.8.24",
         "mockery/mockery": "^0.9.4"
     },
     "extra": {

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -38,7 +38,7 @@ final class TypeResolver
         'mixed' => 'phpDocumentor\Reflection\Types\Mixed',
         'array' => 'phpDocumentor\Reflection\Types\Array_',
         'resource' => 'phpDocumentor\Reflection\Types\Resource',
-        'void' => 'phpDocumentor\Reflection\Types\Void',
+        'void' => 'phpDocumentor\Reflection\Types\Void_',
         'null' => 'phpDocumentor\Reflection\Types\Null_',
         'scalar' => 'phpDocumentor\Reflection\Types\Scalar',
         'callback' => 'phpDocumentor\Reflection\Types\Callable_',

--- a/src/Types/Void_.php
+++ b/src/Types/Void_.php
@@ -20,7 +20,7 @@ use phpDocumentor\Reflection\Type;
  * Void is generally only used when working with return types as it signifies that the method intentionally does not
  * return any value.
  */
-final class Void implements Type
+final class Void_ implements Type
 {
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -373,7 +373,7 @@ class TypeResolverTest extends \PHPUnit_Framework_TestCase
             ['scalar', 'phpDocumentor\Reflection\Types\Scalar'],
             ['object', 'phpDocumentor\Reflection\Types\Object_'],
             ['mixed', 'phpDocumentor\Reflection\Types\Mixed'],
-            ['void', 'phpDocumentor\Reflection\Types\Void'],
+            ['void', 'phpDocumentor\Reflection\Types\Void_'],
             ['$this', 'phpDocumentor\Reflection\Types\This'],
             ['static', 'phpDocumentor\Reflection\Types\Static_'],
             ['self', 'phpDocumentor\Reflection\Types\Self_'],


### PR DESCRIPTION
Fixing the followint failure:

```
1) phpDocumentor\Reflection\TypeResolverTest::testResolvingKeywords with
data set #15 ('void', 'phpDocumentor\Reflection\Types\Void')
PHPUnit_Framework_Exception: Argument #1 (No Value) of
PHPUnit_Framework_Assert::assertInstanceOf() must be a class or
interface name
```
**This is a BC break**
phpDocumentor/ReflectionDocBlock#75 updated phpDocumentor/ReflectionDocBlock accordingly. If other packages need an update too, please let me know, I'm happy to help.