### PR TITLE
Renamed type Void as this is a reserved classname keyword in PHP 7.1

### DIFF
--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -38,7 +38,7 @@ final class TypeResolver
         'mixed' => 'phpDocumentor\Reflection\Types\Mixed',
         'array' => 'phpDocumentor\Reflection\Types\Array_',
         'resource' => 'phpDocumentor\Reflection\Types\Resource',
-        'void' => 'phpDocumentor\Reflection\Types\Void',
+        'void' => 'phpDocumentor\Reflection\Types\Void_',
         'null' => 'phpDocumentor\Reflection\Types\Null_',
         'scalar' => 'phpDocumentor\Reflection\Types\Scalar',
         'callback' => 'phpDocumentor\Reflection\Types\Callable_',

--- a/src/Types/Void_.php
+++ b/src/Types/Void_.php
@@ -20,7 +20,7 @@ use phpDocumentor\Reflection\Type;
  * Void is generally only used when working with return types as it signifies that the method intentionally does not
  * return any value.
  */
-final class Void implements Type
+final class Void_ implements Type
 {
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -373,7 +373,7 @@ class TypeResolverTest extends \PHPUnit_Framework_TestCase
             ['scalar', 'phpDocumentor\Reflection\Types\Scalar'],
             ['object', 'phpDocumentor\Reflection\Types\Object_'],
             ['mixed', 'phpDocumentor\Reflection\Types\Mixed'],
-            ['void', 'phpDocumentor\Reflection\Types\Void'],
+            ['void', 'phpDocumentor\Reflection\Types\Void_'],
             ['$this', 'phpDocumentor\Reflection\Types\This'],
             ['static', 'phpDocumentor\Reflection\Types\Static_'],
             ['self', 'phpDocumentor\Reflection\Types\Self_'],


### PR DESCRIPTION
Testing Symfony with PHP 7.1 :  


Fatal error: Cannot use 'Void' as class name as it is reserved in /home/jpauli/www/symfony/Symfony/vendor/phpdocumentor/type-resolver/src/Types/Void.php on line 23