### PR TITLE
PHP 7 compatibility - patch 1

### DIFF
--- a/src/Types/Resource.php
+++ b/src/Types/Resource.php
@@ -17,7 +17,7 @@ use phpDocumentor\Reflection\Type;
 /**
  * Value Object representing the 'resource' Type.
  */
-final class Resource implements Type
+final class Resource_ implements Type
 {
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.


### PR DESCRIPTION
Classes with names int, string, float, and bool as well as resource, object, mixed, and numeric are forbidden in PHP 7.
http://php.net/manual/en/reserved.other-reserved-words.php
