### PR TITLE
PHP 7 compatibility - patch 2

### DIFF
--- a/src/Types/Mixed.php
+++ b/src/Types/Mixed.php
@@ -17,7 +17,7 @@ use phpDocumentor\Reflection\Type;
 /**
  * Value Object representing an unknown, or mixed, type.
  */
-final class Mixed implements Type
+final class Mixed_ implements Type
 {
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.


### PR DESCRIPTION
Classes with names int, string, float, and bool as well as resource, object, mixed, and numeric are forbidden in PHP 7.
http://php.net/manual/en/reserved.other-reserved-words.php
