### PR TITLE
Iterating over compound types using foreach loop

### DIFF
--- a/src/Types/Compound.php
+++ b/src/Types/Compound.php
@@ -12,6 +12,8 @@
 
 namespace phpDocumentor\Reflection\Types;
 
+use ArrayIterator;
+use IteratorAggregate;
 use phpDocumentor\Reflection\Type;
 
 /**
@@ -21,7 +23,7 @@ use phpDocumentor\Reflection\Type;
  * using an OR operator (`|`). This combination of types signifies that whatever is associated with this compound type
  * may contain a value with any of the given types.
  */
-final class Compound implements Type
+final class Compound implements Type, IteratorAggregate
 {
     /** @var Type[] */
     private $types;
@@ -79,5 +81,13 @@ final class Compound implements Type
     public function __toString()
     {
         return implode('|', $this->types);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getIterator()
+    {
+        return new ArrayIterator($this->types);
     }
 }

--- a/tests/unit/Types/CompoundTest.php
+++ b/tests/unit/Types/CompoundTest.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\Types;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Reflection\Types\Compound
+ */
+class CompoundTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @covers ::__construct
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage A compound type can only have other types as elements
+     */
+    public function testCompoundCannotBeConstructedFromType()
+    {
+        new Compound(['foo']);
+    }
+
+    /**
+     * @covers ::get
+     *
+     * @uses \phpDocumentor\Reflection\Types\Compound::__construct
+     * @uses \phpDocumentor\Reflection\Types\Compound::has
+     * @uses \phpDocumentor\Reflection\Types\Integer
+     */
+    public function testCompoundGetType()
+    {
+        $integer = new Integer();
+
+        $this->assertSame($integer, (new Compound([$integer]))->get(0));
+    }
+
+    /**
+     * @covers ::get
+     *
+     * @uses \phpDocumentor\Reflection\Types\Compound::__construct
+     * @uses \phpDocumentor\Reflection\Types\Compound::has
+     */
+    public function testCompoundGetNotExistingType()
+    {
+        $this->assertNull((new Compound([]))->get(0));
+    }
+
+    /**
+     * @covers ::has
+     *
+     * @uses \phpDocumentor\Reflection\Types\Compound::__construct
+     * @uses \phpDocumentor\Reflection\Types\Integer
+     */
+    public function testCompoundHasType()
+    {
+        $this->assertTrue((new Compound([new Integer()]))->has(0));
+    }
+
+    /**
+     * @covers ::has
+     *
+     * @uses \phpDocumentor\Reflection\Types\Compound::__construct
+     */
+    public function testCompoundHasNotExistingType()
+    {
+        $this->assertFalse((new Compound([]))->has(0));
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::__toString
+     *
+     * @uses \phpDocumentor\Reflection\Types\Integer
+     * @uses \phpDocumentor\Reflection\Types\Boolean
+     */
+    public function testCompoundCanBeConstructedAndStringifiedCorrectly()
+    {
+        $this->assertSame('int|bool', (string)(new Compound([new Integer(), new Boolean()])));
+    }
+
+    /**
+     * @covers ::getIterator
+     *
+     * @uses \phpDocumentor\Reflection\Types\Compound::__construct
+     * @uses \phpDocumentor\Reflection\Types\Integer
+     * @uses \phpDocumentor\Reflection\Types\Boolean
+     */
+    public function testCompoundCanBeIterated()
+    {
+        $types = [new Integer(), new Boolean()];
+
+        foreach (new Compound($types) as $index => $type) {
+            $this->assertSame($types[$index], $type);
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

It's little bit awkward to iterate over types incapsulated inside compound type.

```php
$compound = new Compound([new Integer(), new Boolean()]);

for ($i = 0; $compound->has($i), $i++) {
    echo $compound->get($i);
}
```

## Changes

* This PR introduces ability to iterate over types incapsulated inside compound type using `foreach` loop.

```php
$compound = new Compound([new Integer(), new Boolean()]);

foreach ($compound as $type) {
    echo $type;
}
```

* `Compound.php` class was 100% unit tested.

## P.S.

TravisCI failed due to "HHVM is no longer supported" issue.