### PR TITLE
Support of collections

### DIFF
--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -5,7 +5,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @copyright 2010-2015 Mike van Riel<mike@phpdoc.org>
+ * @copyright 2010-2017 Mike van Riel<mike@phpdoc.org>
  * @license   http://www.opensource.org/licenses/mit-license.php MIT
  * @link      http://phpdoc.org
  */

--- a/src/Types/AbstractList.php
+++ b/src/Types/AbstractList.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2015 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\Types;
+
+use phpDocumentor\Reflection\Type;
+
+/**
+ * Represents a list of values. This is an abstract class for Array_ and Collection.
+ *
+ */
+abstract class AbstractList implements Type
+{
+    /** @var Type */
+    protected $valueType;
+
+    /** @var Type|null */
+    protected $keyType;
+
+    /** @var Type */
+    protected $defaultKeyType;
+
+    /**
+     * Initializes this representation of an array with the given Type.
+     *
+     * @param Type $valueType
+     * @param Type $keyType
+     */
+    public function __construct(Type $valueType = null, Type $keyType = null)
+    {
+        if ($valueType === null) {
+            $valueType = new Mixed_();
+        }
+
+        $this->valueType = $valueType;
+        $this->defaultKeyType = new Compound([ new String_(), new Integer() ]);
+        $this->keyType = $keyType;
+
+    }
+
+    /**
+     * Returns the type for the keys of this array.
+     *
+     * @return Type
+     */
+    public function getKeyType()
+    {
+        if ($this->keyType === null) {
+            return $this->defaultKeyType;
+        }
+        return $this->keyType;
+    }
+
+    /**
+     * Returns the value for the keys of this array.
+     *
+     * @return Type
+     */
+    public function getValueType()
+    {
+        return $this->valueType;
+    }
+
+    /**
+     * Returns a rendered output of the Type as it would be used in a DocBlock.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if ($this->keyType) {
+            return 'array<'.$this->keyType.','.$this->valueType.'>';
+        }
+
+        if ($this->valueType instanceof Mixed_) {
+            return 'array';
+        }
+
+        if ($this->valueType instanceof Compound) {
+            return '(' . $this->valueType . ')[]';
+        }
+
+        return $this->valueType . '[]';
+    }
+}

--- a/src/Types/Array_.php
+++ b/src/Types/Array_.php
@@ -12,8 +12,6 @@
 
 namespace phpDocumentor\Reflection\Types;
 
-use phpDocumentor\Reflection\Type;
-
 /**
  * Represents an array type as described in the PSR-5, the PHPDoc Standard.
  *
@@ -23,77 +21,6 @@ use phpDocumentor\Reflection\Type;
  * 2. Types (`string[]`), where the value type is provided by preceding an opening and closing square bracket with a
  *    type name.
  */
-class Array_ implements Type
+final class Array_ extends AbstractList
 {
-    /** @var Type */
-    protected $valueType;
-
-    /** @var Type|null */
-    protected $keyType;
-
-    /** @var Type */
-    protected $defaultKeyType;
-
-    /**
-     * Initializes this representation of an array with the given Type.
-     *
-     * @param Type $valueType
-     * @param Type $keyType
-     */
-    public function __construct(Type $valueType = null, Type $keyType = null)
-    {
-        if ($valueType === null) {
-            $valueType = new Mixed_();
-        }
-
-        $this->valueType = $valueType;
-        $this->defaultKeyType = new Compound([ new String_(), new Integer() ]);
-        $this->keyType = $keyType;
-
-    }
-
-    /**
-     * Returns the type for the keys of this array.
-     *
-     * @return Type
-     */
-    public function getKeyType()
-    {
-        if ($this->keyType === null) {
-            return $this->defaultKeyType;
-        }
-        return $this->keyType;
-    }
-
-    /**
-     * Returns the value for the keys of this array.
-     *
-     * @return Type
-     */
-    public function getValueType()
-    {
-        return $this->valueType;
-    }
-
-    /**
-     * Returns a rendered output of the Type as it would be used in a DocBlock.
-     *
-     * @return string
-     */
-    public function __toString()
-    {
-        if ($this->keyType) {
-            return 'array<'.$this->keyType.','.$this->valueType.'>';
-        }
-
-        if ($this->valueType instanceof Mixed_) {
-            return 'array';
-        }
-
-        if ($this->valueType instanceof Compound) {
-            return '(' . $this->valueType . ')[]';
-        }
-
-        return $this->valueType . '[]';
-    }
 }

--- a/src/Types/Array_.php
+++ b/src/Types/Array_.php
@@ -23,31 +23,33 @@ use phpDocumentor\Reflection\Type;
  * 2. Types (`string[]`), where the value type is provided by preceding an opening and closing square bracket with a
  *    type name.
  */
-final class Array_ implements Type
+class Array_ implements Type
 {
     /** @var Type */
-    private $valueType;
+    protected $valueType;
+
+    /** @var Type|null */
+    protected $keyType;
 
     /** @var Type */
-    private $keyType;
+    protected $defaultKeyType;
 
     /**
-     * Initializes this representation of an array with the given Type or Fqsen.
+     * Initializes this representation of an array with the given Type.
      *
      * @param Type $valueType
      * @param Type $keyType
      */
     public function __construct(Type $valueType = null, Type $keyType = null)
     {
-        if ($keyType === null) {
-            $keyType = new Compound([ new String_(), new Integer() ]);
-        }
         if ($valueType === null) {
             $valueType = new Mixed_();
         }
 
         $this->valueType = $valueType;
+        $this->defaultKeyType = new Compound([ new String_(), new Integer() ]);
         $this->keyType = $keyType;
+
     }
 
     /**
@@ -57,6 +59,9 @@ final class Array_ implements Type
      */
     public function getKeyType()
     {
+        if ($this->keyType === null) {
+            return $this->defaultKeyType;
+        }
         return $this->keyType;
     }
 
@@ -77,6 +82,10 @@ final class Array_ implements Type
      */
     public function __toString()
     {
+        if ($this->keyType) {
+            return 'array<'.$this->keyType.','.$this->valueType.'>';
+        }
+
         if ($this->valueType instanceof Mixed_) {
             return 'array';
         }

--- a/src/Types/Collection.php
+++ b/src/Types/Collection.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2015 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\Types;
+
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Fqsen;
+
+/**
+ * Represents a collection type as described in the PSR-5, the PHPDoc Standard.
+ *
+ * A collection can be represented in two forms:
+ *
+ * 1. `ACollectionObject<aValueType>`
+ * 2. `ACollectionObject<aValueType,aKeyType>`
+ *
+ * - ACollectionObject can be 'array' or an object that can act as an array
+ * - aValueType and aKeyType can be any type expression
+ */
+class Collection extends Array_
+{
+
+    /** @var Fqsen */
+    private $fqsen;
+
+    /**
+     * Initializes this representation of an array with the given Type or Fqsen.
+     *
+     * @param Type $valueType
+     * @param Type $keyType
+     */
+    public function __construct(Fqsen $fqsen, Type $valueType, Type $keyType = null)
+    {
+        parent::__construct($valueType, $keyType);
+
+        $this->fqsen = $fqsen;
+
+    }
+
+    /**
+     * Returns the FQSEN associated with this object.
+     *
+     * @return Fqsen
+     */
+    public function getFqsen()
+    {
+        return $this->fqsen;
+    }
+
+    /**
+     * Returns a rendered output of the Type as it would be used in a DocBlock.
+     *
+     * @return string
+     */
+    public function __toString()
+    {
+        if ($this->keyType === null) {
+            return $this->fqsen.'<'.$this->valueType . '>';
+        }
+        return $this->fqsen.'<'.$this->keyType . ',' . $this->valueType . '>';
+    }
+}

--- a/src/Types/Collection.php
+++ b/src/Types/Collection.php
@@ -26,7 +26,7 @@ use phpDocumentor\Reflection\Fqsen;
  * - ACollectionObject can be 'array' or an object that can act as an array
  * - aValueType and aKeyType can be any type expression
  */
-class Collection extends Array_
+final class Collection extends AbstractList
 {
 
     /** @var Fqsen */
@@ -43,7 +43,6 @@ class Collection extends Array_
         parent::__construct($valueType, $keyType);
 
         $this->fqsen = $fqsen;
-
     }
 
     /**
@@ -66,6 +65,7 @@ class Collection extends Array_
         if ($this->keyType === null) {
             return $this->fqsen.'<'.$this->valueType . '>';
         }
+
         return $this->fqsen.'<'.$this->keyType . ',' . $this->valueType . '>';
     }
 }

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @copyright 2010-2015 Mike van Riel<mike@phpdoc.org>
+ * @license   http://www.opensource.org/licenses/mit-license.php MIT
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection;
+
+use Mockery as m;
+use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\Collection;
+use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\Types\Iterable_;
+use phpDocumentor\Reflection\Types\Nullable;
+use phpDocumentor\Reflection\Types\Object_;
+use phpDocumentor\Reflection\Types\Boolean;
+use Mockery\MockInterface;
+use phpDocumentor\Reflection\Types\String_;
+
+/**
+ * @coversDefaultClass phpDocumentor\Reflection\TypeResolver
+ */
+class CollectionResolverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     *
+     * @covers ::__construct
+     * @covers ::resolve
+     * @covers ::<private>
+     *
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Compound
+     * @uses \phpDocumentor\Reflection\Types\Collection
+     * @uses \phpDocumentor\Reflection\Types\String_
+     */
+    public function testResolvingCollection() {
+        $fixture = new TypeResolver();
+
+        /** @var Collection $resolvedType */
+        $resolvedType = $fixture->resolve('ArrayObject<string>', new Context(''));
+
+        $this->assertInstanceOf(Collection::class, $resolvedType);
+        $this->assertSame('\\ArrayObject<string>', (string)$resolvedType);
+
+        $this->assertEquals('\\ArrayObject', (string) $resolvedType->getFqsen());
+
+        /** @var Array_ $valueType */
+        $valueType = $resolvedType->getValueType();
+
+        /** @var Compound $keyType */
+        $keyType = $resolvedType->getKeyType();
+
+        $this->assertInstanceOf(Types\String_::class, $valueType);
+        $this->assertInstanceOf(Types\Compound::class, $keyType);
+    }
+
+    /**
+     *
+     * @covers ::__construct
+     * @covers ::resolve
+     * @covers ::<private>
+     *
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Compound
+     * @uses \phpDocumentor\Reflection\Types\Collection
+     * @uses \phpDocumentor\Reflection\Types\String_
+     */
+    public function testResolvingCollectionWithKeyType() {
+        $fixture = new TypeResolver();
+
+        /** @var Collection $resolvedType */
+        $resolvedType = $fixture->resolve('ArrayObject<string[],Iterator>', new Context(''));
+
+        $this->assertInstanceOf(Collection::class, $resolvedType);
+        $this->assertSame('\\ArrayObject<string[],\\Iterator>', (string)$resolvedType);
+
+        $this->assertEquals('\\ArrayObject', (string) $resolvedType->getFqsen());
+
+        /** @var Object_ $valueType */
+        $valueType = $resolvedType->getValueType();
+
+        /** @var Array_ $keyType */
+        $keyType = $resolvedType->getKeyType();
+
+        $this->assertInstanceOf(Types\Object_::class, $valueType);
+        $this->assertEquals('\\Iterator', (string) $valueType->getFqsen());
+        $this->assertInstanceOf(Types\Array_::class, $keyType);
+        $this->assertInstanceOf(Types\String_::class, $keyType->getValueType());
+    }
+
+    /**
+     *
+     * @covers ::__construct
+     * @covers ::resolve
+     * @covers ::<private>
+     *
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Compound
+     * @uses \phpDocumentor\Reflection\Types\Collection
+     * @uses \phpDocumentor\Reflection\Types\String_
+     */
+    public function testResolvingArrayCollection() {
+        $fixture = new TypeResolver();
+
+        /** @var Collection $resolvedType */
+        $resolvedType = $fixture->resolve('array<string>', new Context(''));
+
+        $this->assertInstanceOf(Array_::class, $resolvedType);
+        $this->assertSame('string[]', (string)$resolvedType);
+
+        /** @var Array_ $valueType */
+        $valueType = $resolvedType->getValueType();
+
+        /** @var Compound $keyType */
+        $keyType = $resolvedType->getKeyType();
+
+        $this->assertInstanceOf(Types\String_::class, $valueType);
+        $this->assertInstanceOf(Types\Compound::class, $keyType);
+    }
+
+    /**
+     *
+     * @covers ::__construct
+     * @covers ::resolve
+     * @covers ::<private>
+     *
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Compound
+     * @uses \phpDocumentor\Reflection\Types\Collection
+     * @uses \phpDocumentor\Reflection\Types\String_
+     */
+    public function testResolvingArrayCollectionWithKey() {
+        $fixture = new TypeResolver();
+
+        /** @var Collection $resolvedType */
+        $resolvedType = $fixture->resolve('array<string,object|array>', new Context(''));
+
+        $this->assertInstanceOf(Array_::class, $resolvedType);
+        $this->assertSame('array<string,object|array>', (string)$resolvedType);
+
+        /** @var Array_ $valueType */
+        $valueType = $resolvedType->getValueType();
+
+        /** @var Compound $keyType */
+        $keyType = $resolvedType->getKeyType();
+
+        $this->assertInstanceOf(Types\String_::class, $keyType);
+        $this->assertInstanceOf(Types\Compound::class, $valueType);
+    }
+
+    /**
+     *
+     * @covers ::__construct
+     * @covers ::resolve
+     * @covers ::<private>
+     *
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Compound
+     * @uses \phpDocumentor\Reflection\Types\Collection
+     * @uses \phpDocumentor\Reflection\Types\String_
+     */
+    public function testResolvingCollectionOfCollection() {
+        $fixture = new TypeResolver();
+
+        /** @var Collection $resolvedType */
+        $resolvedType = $fixture->resolve('ArrayObject<string|integer|double,ArrayObject<DateTime>>', new Context(''));
+
+        $this->assertInstanceOf(Collection::class, $resolvedType);
+        $this->assertSame('\\ArrayObject<string|int|float,\\ArrayObject<\\DateTime>>', (string)$resolvedType);
+
+        $this->assertEquals('\\ArrayObject', (string) $resolvedType->getFqsen());
+
+        /** @var Collection $valueType */
+        $valueType = $resolvedType->getValueType();
+        $this->assertInstanceOf(Types\Collection::class, $valueType);
+        $this->assertInstanceOf(Types\Object_::class, $valueType->getValueType());
+        $this->assertEquals('\\ArrayObject', (string) $valueType->getFqsen());
+        $this->assertEquals('\\DateTime', (string) $valueType->getValueType()->getFqsen());
+
+        /** @var Compound $keyType */
+        $keyType = $resolvedType->getKeyType();
+        $this->assertInstanceOf(Types\Compound::class, $keyType);
+        $this->assertInstanceOf(Types\String_::class, $keyType->get(0));
+        $this->assertInstanceOf(Types\Integer::class, $keyType->get(1));
+        $this->assertInstanceOf(Types\Float_::class, $keyType->get(2));
+    }
+
+
+    /**
+     * @covers ::__construct
+     * @covers ::resolve
+     * @covers ::<private>
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage An array can have only integers or strings as keys
+     */
+    public function testBadArrayCollectionKey()
+    {
+        $fixture = new TypeResolver();
+        $fixture->resolve('array<object,string>', new Context(''));
+
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::resolve
+     * @covers ::<private>
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Unexpected collection operator "<", class name is missing
+     */
+    public function testMissingStartCollection()
+    {
+        $fixture = new TypeResolver();
+        $fixture->resolve('<string>', new Context(''));
+
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::resolve
+     * @covers ::<private>
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Collection: ">" is missing
+     */
+    public function testMissingEndCollection()
+    {
+        $fixture = new TypeResolver();
+        $fixture->resolve('ArrayObject<object|string', new Context(''));
+
+    }
+
+
+    /**
+     * @covers ::__construct
+     * @covers ::resolve
+     * @covers ::<private>
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage string is not a collection
+     */
+    public function testBadCollectionClass()
+    {
+        $fixture = new TypeResolver();
+        $fixture->resolve('string<integer>', new Context(''));
+
+    }
+}

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -12,19 +12,14 @@
 
 namespace phpDocumentor\Reflection;
 
-use Mockery as m;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Collection;
 use phpDocumentor\Reflection\Types\Compound;
 use phpDocumentor\Reflection\Types\Context;
-use phpDocumentor\Reflection\Types\Iterable_;
-use phpDocumentor\Reflection\Types\Nullable;
 use phpDocumentor\Reflection\Types\Object_;
-use phpDocumentor\Reflection\Types\Boolean;
-use Mockery\MockInterface;
-use phpDocumentor\Reflection\Types\String_;
 
 /**
+ * @covers ::<private>
  * @coversDefaultClass phpDocumentor\Reflection\TypeResolver
  */
 class CollectionResolverTest extends \PHPUnit_Framework_TestCase
@@ -33,7 +28,6 @@ class CollectionResolverTest extends \PHPUnit_Framework_TestCase
      *
      * @covers ::__construct
      * @covers ::resolve
-     * @covers ::<private>
      *
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
@@ -65,7 +59,6 @@ class CollectionResolverTest extends \PHPUnit_Framework_TestCase
      *
      * @covers ::__construct
      * @covers ::resolve
-     * @covers ::<private>
      *
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
@@ -99,7 +92,6 @@ class CollectionResolverTest extends \PHPUnit_Framework_TestCase
      *
      * @covers ::__construct
      * @covers ::resolve
-     * @covers ::<private>
      *
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
@@ -129,7 +121,6 @@ class CollectionResolverTest extends \PHPUnit_Framework_TestCase
      *
      * @covers ::__construct
      * @covers ::resolve
-     * @covers ::<private>
      *
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
@@ -159,7 +150,6 @@ class CollectionResolverTest extends \PHPUnit_Framework_TestCase
      *
      * @covers ::__construct
      * @covers ::resolve
-     * @covers ::<private>
      *
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
@@ -192,11 +182,9 @@ class CollectionResolverTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Types\Float_::class, $keyType->get(2));
     }
 
-
     /**
      * @covers ::__construct
      * @covers ::resolve
-     * @covers ::<private>
      * @expectedException \RuntimeException
      * @expectedExceptionMessage An array can have only integers or strings as keys
      */
@@ -204,13 +192,11 @@ class CollectionResolverTest extends \PHPUnit_Framework_TestCase
     {
         $fixture = new TypeResolver();
         $fixture->resolve('array<object,string>', new Context(''));
-
     }
 
     /**
      * @covers ::__construct
      * @covers ::resolve
-     * @covers ::<private>
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Unexpected collection operator "<", class name is missing
      */
@@ -218,13 +204,11 @@ class CollectionResolverTest extends \PHPUnit_Framework_TestCase
     {
         $fixture = new TypeResolver();
         $fixture->resolve('<string>', new Context(''));
-
     }
 
     /**
      * @covers ::__construct
      * @covers ::resolve
-     * @covers ::<private>
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Collection: ">" is missing
      */
@@ -232,14 +216,11 @@ class CollectionResolverTest extends \PHPUnit_Framework_TestCase
     {
         $fixture = new TypeResolver();
         $fixture->resolve('ArrayObject<object|string', new Context(''));
-
     }
-
 
     /**
      * @covers ::__construct
      * @covers ::resolve
-     * @covers ::<private>
      * @expectedException \RuntimeException
      * @expectedExceptionMessage string is not a collection
      */
@@ -247,6 +228,34 @@ class CollectionResolverTest extends \PHPUnit_Framework_TestCase
     {
         $fixture = new TypeResolver();
         $fixture->resolve('string<integer>', new Context(''));
+    }
 
+    /**
+     *
+     * @covers ::__construct
+     * @covers ::resolve
+     *
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Compound
+     * @uses \phpDocumentor\Reflection\Types\Collection
+     * @uses \phpDocumentor\Reflection\Types\String_
+     */
+    public function testResolvingCollectionAsArray() {
+        $fixture = new TypeResolver();
+
+        /** @var Collection $resolvedType */
+        $resolvedType = $fixture->resolve('array<string,float>', new Context(''));
+
+        $this->assertInstanceOf(Array_::class, $resolvedType);
+        $this->assertSame('array<string,float>', (string)$resolvedType);
+
+        /** @var Array_ $valueType */
+        $valueType = $resolvedType->getValueType();
+
+        /** @var Compound $keyType */
+        $keyType = $resolvedType->getKeyType();
+
+        $this->assertInstanceOf(Types\Float_::class, $valueType);
+        $this->assertInstanceOf(Types\String_::class, $keyType);
     }
 }

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -172,9 +172,9 @@ class TypeResolverTest extends \PHPUnit_Framework_TestCase
      * @covers ::resolve
      * @covers ::<private>
      *
-     * @uses phpDocumentor\Reflection\Types\Context
-     * @uses phpDocumentor\Reflection\Types\Array_
-     * @uses phpDocumentor\Reflection\Types\String_
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Array_
+     * @uses \phpDocumentor\Reflection\Types\String_
      */
     public function testResolvingNestedTypedArrays()
     {


### PR DESCRIPTION
Support of the syntax to declare collections as described in psr-5, like `collectionobject<valuetype>` or `collectionobject<keytype,valuetype>`.