### PR TITLE
Pseudo keywords as "scalar", "mixed" etc should be check case sensitive

### DIFF
--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -331,7 +331,7 @@ final class TypeResolver
      */
     private function isKeyword($type)
     {
-        return in_array(strtolower($type), array_keys($this->keywords), true);
+        return array_key_exists(strtolower($type), $this->keywords);
     }
 
     /**

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -47,19 +47,13 @@ final class TypeResolver
     private $keywords = array(
         'string' => Types\String_::class,
         'int' => Types\Integer::class,
-        'integer' => Types\Integer::class,
         'bool' => Types\Boolean::class,
-        'boolean' => Types\Boolean::class,
         'float' => Types\Float_::class,
-        'double' => Types\Float_::class,
         'object' => Object_::class,
-        'mixed' => Types\Mixed_::class,
         'array' => Array_::class,
         'resource' => Types\Resource_::class,
         'void' => Types\Void_::class,
         'null' => Types\Null_::class,
-        'scalar' => Types\Scalar::class,
-        'callback' => Types\Callable_::class,
         'callable' => Types\Callable_::class,
         'false' => Types\Boolean::class,
         'true' => Types\Boolean::class,
@@ -68,6 +62,16 @@ final class TypeResolver
         'static' => Types\Static_::class,
         'parent' => Types\Parent_::class,
         'iterable' => Iterable_::class,
+    );
+
+    /** @var string[] List of recognized pseudo keywords and unto which Value Object they map */
+    private $pseudoKeywords = array(
+        'integer' => Types\Integer::class,
+        'double' => Types\Float_::class,
+        'boolean' => Types\Boolean::class,
+        'mixed' => Types\Mixed_::class,
+        'scalar' => Types\Scalar::class,
+        'callback' => Types\Callable_::class,
     );
 
     /** @var FqsenResolver */
@@ -262,6 +266,8 @@ final class TypeResolver
         switch (true) {
             case $this->isKeyword($type):
                 return $this->resolveKeyword($type);
+            case $this->isPseudoKeyword($type):
+                return $this->resolvePseudoKeyword($type);
             case $this->isTypedArray($type):
                 return $this->resolveTypedArray($type, $context);
             case $this->isFqsen($type):
@@ -329,6 +335,18 @@ final class TypeResolver
     }
 
     /**
+     * Detects whether the given type represents a PHPDoc pseudo keyword.
+     *
+     * @param string $type A relative or absolute type as defined in the phpDocumentor documentation.
+     *
+     * @return bool
+     */
+    private function isPseudoKeyword($type)
+    {
+        return array_key_exists($type, $this->pseudoKeywords);
+    }
+
+    /**
      * Detects whether the given type represents a relative structural element name.
      *
      * @param string $type A relative or absolute type as defined in the phpDocumentor documentation.
@@ -375,6 +393,20 @@ final class TypeResolver
     private function resolveKeyword($type)
     {
         $className = $this->keywords[strtolower($type)];
+
+        return new $className();
+    }
+
+    /**
+     * Resolves the given pseudo keyword (such as `scalar`) into a Type object representing that keyword.
+     *
+     * @param string $type
+     *
+     * @return Type
+     */
+    private function resolvePseudoKeyword($type)
+    {
+        $className = $this->pseudoKeywords[$type];
 
         return new $className();
     }

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -45,10 +45,43 @@ class TypeResolverTest extends \PHPUnit_Framework_TestCase
     public function testResolvingKeywords($keyword, $expectedClass)
     {
         $fixture = new TypeResolver();
+        $context = new Context('');
 
-        $resolvedType = $fixture->resolve($keyword, new Context(''));
+        $resolvedType = $fixture->resolve($keyword, $context);
 
         $this->assertInstanceOf($expectedClass, $resolvedType);
+
+        $resolvedType = $fixture->resolve(strtoupper($keyword), $context);
+
+        $this->assertInstanceOf($expectedClass, $resolvedType);
+    }
+
+    /**
+     * @param string $pseudoKeyword
+     * @param string $expectedClass
+     *
+     * @covers ::__construct
+     * @covers ::resolve
+     * @covers ::<private>
+     *
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Array_
+     * @uses \phpDocumentor\Reflection\Types\Object_
+     *
+     * @dataProvider providePseudoKeywords
+     */
+    public function testResolvingPseudoKeywords($pseudoKeyword, $expectedClass)
+    {
+        $fixture = new TypeResolver();
+        $context = new Context('');
+
+        $resolvedType = $fixture->resolve($pseudoKeyword, $context);
+
+        $this->assertInstanceOf($expectedClass, $resolvedType);
+
+        $resolvedType = $fixture->resolve(strtoupper($pseudoKeyword), $context);
+
+        $this->assertInstanceOf(Object_::class, $resolvedType);
     }
 
     /**
@@ -554,25 +587,36 @@ class TypeResolverTest extends \PHPUnit_Framework_TestCase
         return [
             ['string', Types\String_::class],
             ['int', Types\Integer::class],
-            ['integer', Types\Integer::class],
             ['float', Types\Float_::class],
-            ['double', Types\Float_::class],
             ['bool', Types\Boolean::class],
-            ['boolean', Types\Boolean::class],
             ['resource', Types\Resource_::class],
             ['null', Types\Null_::class],
             ['callable', Types\Callable_::class],
-            ['callback', Types\Callable_::class],
             ['array', Array_::class],
-            ['scalar', Types\Scalar::class],
             ['object', Object_::class],
-            ['mixed', Types\Mixed_::class],
             ['void', Types\Void_::class],
             ['$this', Types\This::class],
             ['static', Types\Static_::class],
             ['self', Types\Self_::class],
             ['parent', Types\Parent_::class],
             ['iterable', Iterable_::class],
+        ];
+    }
+
+    /**
+     * Returns a list of pseudo keywords and expected classes that are created from them.
+     *
+     * @return string[][]
+     */
+    public function providePseudoKeywords()
+    {
+        return [
+            ['integer', Types\Integer::class],
+            ['double', Types\Float_::class],
+            ['boolean', Types\Boolean::class],
+            ['callback', Types\Callable_::class],
+            ['scalar', Types\Scalar::class],
+            ['mixed', Types\Mixed_::class],
         ];
     }
 


### PR DESCRIPTION
Fix of https://github.com/phpDocumentor/TypeResolver/issues/43