### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,13 @@
 language: php
 dist: trusty
 php:
-  - 5.5
-  - 5.6
   - 7.0
   - 7.1
-  - hhvm
   - nightly
 
 matrix:
   allow_failures:
     - php:
-      - hhvm
       - nightly
 
 cache:
@@ -27,7 +23,7 @@ before_script:
  - composer install --no-interaction
 
 after_script:
-  - if [ $TRAVIS_PHP_VERSION = '5.6' ]; then wget https://scrutinizer-ci.com/ocular.phar; php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - if [ $TRAVIS_PHP_VERSION = '7.0' ]; then wget https://scrutinizer-ci.com/ocular.phar; php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
 
 notifications:
   irc: "irc.freenode.org#phpdocumentor"

--- a/composer.json
+++ b/composer.json
@@ -1,23 +1,30 @@
 {
-    "name":    "phpdocumentor/type-resolver",
-    "type":    "library",
+    "name": "phpdocumentor/type-resolver",
+    "type": "library",
     "license": "MIT",
     "authors": [
-        {"name": "Mike van Riel", "email": "me@mikevanriel.com"}
+        {
+          "name": "Mike van Riel",
+          "email": "me@mikevanriel.com"
+        }
     ],
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^7.0",
         "phpdocumentor/reflection-common": "^1.0"
     },
     "autoload": {
-        "psr-4": {"phpDocumentor\\Reflection\\": ["src/"]}
+        "psr-4": {
+          "phpDocumentor\\Reflection\\": "src"
+        }
     },
     "autoload-dev": {
-        "psr-4": {"phpDocumentor\\Reflection\\": ["tests/unit"]}
+        "psr-4": {
+          "phpDocumentor\\Reflection\\": "tests/unit"
+        }
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7 ||^4.8.35",
-        "mockery/mockery": "^0.9.4"
+        "phpunit/phpunit": "^6.4",
+        "mockery/mockery": "^1.0"
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "psr-4": {"phpDocumentor\\Reflection\\": ["tests/unit"]}
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.2||^4.8.24",
+        "phpunit/phpunit": "^5.7 ||^4.8.35",
         "mockery/mockery": "^0.9.4"
     },
     "extra": {

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -17,12 +17,13 @@ use phpDocumentor\Reflection\Types\Collection;
 use phpDocumentor\Reflection\Types\Compound;
 use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\Types\Object_;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers ::<private>
  * @coversDefaultClass phpDocumentor\Reflection\TypeResolver
  */
-class CollectionResolverTest extends \PHPUnit_Framework_TestCase
+class CollectionResolverTest extends TestCase
 {
     /**
      *

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -22,11 +22,12 @@ use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\Boolean;
 use Mockery\MockInterface;
 use phpDocumentor\Reflection\Types\String_;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @coversDefaultClass phpDocumentor\Reflection\TypeResolver
  */
-class TypeResolverTest extends \PHPUnit_Framework_TestCase
+class TypeResolverTest extends TestCase
 {
     /**
      * @param string $keyword

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -29,6 +29,15 @@ use PHPUnit\Framework\TestCase;
  */
 class TypeResolverTest extends TestCase
 {
+
+    /**
+     * Call Mockery::close after each test.
+     */
+    public function tearDown()
+    {
+        m::close();
+    }
+
     /**
      * @param string $keyword
      * @param string $expectedClass

--- a/tests/unit/Types/CompoundTest.php
+++ b/tests/unit/Types/CompoundTest.php
@@ -12,10 +12,12 @@
 
 namespace phpDocumentor\Reflection\Types;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @coversDefaultClass \phpDocumentor\Reflection\Types\Compound
  */
-class CompoundTest extends \PHPUnit_Framework_TestCase
+class CompoundTest extends TestCase
 {
     /**
      * @covers ::__construct

--- a/tests/unit/Types/ContextFactoryTest.php
+++ b/tests/unit/Types/ContextFactoryTest.php
@@ -18,12 +18,13 @@ namespace phpDocumentor\Reflection\Types {
         phpDocumentor\Reflection\DocBlock\Tag;
     use phpDocumentor;
     use \ReflectionClass; // yes, the slash is part of the test
+    use PHPUnit\Framework\TestCase;
 
     /**
      * @coversDefaultClass \phpDocumentor\Reflection\Types\ContextFactory
      * @covers ::<private>
      */
-    class ContextFactoryTest extends \PHPUnit_Framework_TestCase
+    class ContextFactoryTest extends TestCase
     {
         /**
          * @covers ::createFromReflector
@@ -51,7 +52,8 @@ namespace phpDocumentor\Reflection\Types {
                 'DocBlock' => DocBlock::class,
                 'Tag' => Tag::class,
                 'phpDocumentor' => 'phpDocumentor',
-                ReflectionClass::class => ReflectionClass::class
+                ReflectionClass::class => ReflectionClass::class,
+                'TestCase' => TestCase::class
             ];
             $context = $fixture->createFromReflector(new ReflectionClass($this));
 
@@ -82,7 +84,8 @@ namespace phpDocumentor\Reflection\Types {
                 'DocBlock'        => DocBlock::class,
                 'Tag'             => Tag::class,
                 'phpDocumentor' => 'phpDocumentor',
-                ReflectionClass::class => ReflectionClass::class
+                ReflectionClass::class => ReflectionClass::class,
+                'TestCase' => TestCase::class,
             ];
             $context = $fixture->createForNamespace(__NAMESPACE__, file_get_contents(__FILE__));
 

--- a/tests/unit/Types/ContextTest.php
+++ b/tests/unit/Types/ContextTest.php
@@ -12,10 +12,12 @@
 
 namespace phpDocumentor\Reflection\Types;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @coversDefaultClass \phpDocumentor\Reflection\Types\Context
  */
-class ContextTest extends \PHPUnit_Framework_TestCase
+class ContextTest extends TestCase
 {
     /**
      * @covers ::__construct

--- a/tests/unit/Types/NullableTest.php
+++ b/tests/unit/Types/NullableTest.php
@@ -12,10 +12,12 @@
 
 namespace phpDocumentor\Reflection\Types;
 
+use PHPUnit\Framework\TestCase;
+
 /**
  * @coversDefaultClass \phpDocumentor\Reflection\Types\Nullable
  */
-class NullableTest extends \PHPUnit_Framework_TestCase
+class NullableTest extends TestCase
 {
     /**
      * @covers ::__construct


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06) and [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.