### PR TITLE
AbstractList: fix array vs mixed difference

### DIFF
--- a/src/Types/AbstractList.php
+++ b/src/Types/AbstractList.php
@@ -82,7 +82,7 @@ abstract class AbstractList implements Type
         }
 
         if ($this->valueType instanceof Mixed_) {
-            return 'array';
+            return 'mixed[]';
         }
 
         if ($this->valueType instanceof Compound) {


### PR DESCRIPTION
```php
/**
 * @param mixed[] $value
 */
public function someMethod(array $value) ...
```

is interpretted incorretly like `array`. That matters, because here it is useful - we **know** there is mixed

```php
/**
 * @param array
 */
public function someMethod(array $value) ...
```

But here not, because we forget to specify the type. And it could be more `SomeType[]`, `string[]` etc.