### PR TITLE
Added missing pesudo-type alias of float

### DIFF
--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -50,6 +50,7 @@ final class TypeResolver
         'integer' => Types\Integer::class,
         'bool' => Types\Boolean::class,
         'boolean' => Types\Boolean::class,
+        'real' => Types\Float_::class,
         'float' => Types\Float_::class,
         'double' => Types\Float_::class,
         'object' => Object_::class,


### PR DESCRIPTION
I noticed that the `real` pesudo-type alias for the pesudo-type `float` was missed from this list, when I was prepping https://github.com/FriendsOfPHP/PHP-CS-Fixer/pull/3354.