### PR TITLE
TypeResolver - Ignore whitespaces around tokens

### DIFF
--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -115,7 +115,7 @@ final class TypeResolver
         }
 
         // split the type string into tokens `|`, `?`, `<`, `>`, `,`, `(`, `)[]`, '<', '>' and type names
-        $tokens = preg_split('/\s*(\\||\\?|<|>|,|\\(|\\)(?:\\[\\])+)\s*/', $type, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+        $tokens = preg_split('/(\\||\\?|<|>|, ?|\\(|\\)(?:\\[\\])+)/', $type, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
         $tokenIterator = new \ArrayIterator($tokens);
 
         return $this->parseTypes($tokenIterator, $context, self::PARSER_IN_COMPOUND);
@@ -198,7 +198,7 @@ final class TypeResolver
 
                 $tokens->next();
             } elseif ($parserContext === self::PARSER_IN_COLLECTION_EXPRESSION
-                && ($token === '>' || $token === ',')
+                && ($token === '>' || trim($token) === ',')
                 ) {
                 break;
             } else {
@@ -407,7 +407,7 @@ final class TypeResolver
         $valueType = $this->parseTypes($tokens, $context, self::PARSER_IN_COLLECTION_EXPRESSION);
         $keyType = null;
 
-        if ($tokens->current() === ',') {
+        if ($tokens->current() !== null && trim($tokens->current()) === ',') {
             // if we have a comma, then we just parsed the key type, not the value type
             $keyType = $valueType;
             if ($isArray) {

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -114,7 +114,7 @@ final class TypeResolver
             $context = new Context('');
         }
 
-        // split the type string into tokens `|`, `?`, `(`, `)[]`, '<', '>' and type names
+        // split the type string into tokens `|`, `?`, `<`, `>`, `,`, `(`, `)[]`, '<', '>' and type names
         $tokens = preg_split('/\s*(\\||\\?|<|>|,|\\(|\\)(?:\\[\\])+)\s*/', $type, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
         $tokenIterator = new \ArrayIterator($tokens);
 

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -115,7 +115,7 @@ final class TypeResolver
         }
 
         // split the type string into tokens `|`, `?`, `(`, `)[]`, '<', '>' and type names
-        $tokens = preg_split('/(\\||\\?|<|>|,|\\(|\\)(?:\\[\\])+)/', $type, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
+        $tokens = preg_split('/\s*(\\||\\?|<|>|,|\\(|\\)(?:\\[\\])+)\s*/', $type, -1, PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE);
         $tokenIterator = new \ArrayIterator($tokens);
 
         return $this->parseTypes($tokenIterator, $context, self::PARSER_IN_COMPOUND);

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -179,6 +179,25 @@ class CollectionResolverTest extends TestCase
     /**
      * @covers ::__construct
      * @covers ::resolve
+     * 
+     * @expectedException \InvalidArgumentException
+     *
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Compound
+     * @uses \phpDocumentor\Reflection\Types\Collection
+     * @uses \phpDocumentor\Reflection\Types\String_
+     */
+    public function testResolvingArrayCollectionWithKeyAndTooManyWhitespace()
+    {
+        $fixture = new TypeResolver();
+
+        /** @var Collection $resolvedType */
+        $resolvedType = $fixture->resolve('array<string,  object|array>', new Context(''));
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::resolve
      *
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -156,6 +156,35 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Collection
      * @uses \phpDocumentor\Reflection\Types\String_
      */
+    public function testResolvingArrayCollectionWithKeyAndWhitespace()
+    {
+        $fixture = new TypeResolver();
+
+        /** @var Collection $resolvedType */
+        $resolvedType = $fixture->resolve('array<string, object|array>', new Context(''));
+
+        $this->assertInstanceOf(Array_::class, $resolvedType);
+        $this->assertSame('array<string,object|array>', (string) $resolvedType);
+
+        /** @var Array_ $valueType */
+        $valueType = $resolvedType->getValueType();
+
+        /** @var Compound $keyType */
+        $keyType = $resolvedType->getKeyType();
+
+        $this->assertInstanceOf(Types\String_::class, $keyType);
+        $this->assertInstanceOf(Types\Compound::class, $valueType);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::resolve
+     *
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Compound
+     * @uses \phpDocumentor\Reflection\Types\Collection
+     * @uses \phpDocumentor\Reflection\Types\String_
+     */
     public function testResolvingCollectionOfCollection()
     {
         $fixture = new TypeResolver();


### PR DESCRIPTION
This is an attempt to fix issue #49. While fixing it it appeared simpler to update the preg split pattern to match (and ignore) whitespaces everywhere, which means following types will work : 

- array<int, string>
- array    <     int   ,    string    >

If it is too open, I can change that to only ignore one|all whitespace after the `,` token.

I also updated the PREG comment.