### PR TITLE
Added correct resolver for classes with aliases out of context

### DIFF
--- a/src/FqsenResolver.php
+++ b/src/FqsenResolver.php
@@ -61,6 +61,31 @@ class FqsenResolver
         // if the first segment is not an alias; prepend namespace name and return
         if (!isset($namespaceAliases[$typeParts[0]])) {
             $namespace = $context->getNamespace();
+
+            // check if class is not a part of the current context
+            foreach ($namespaceAliases as $value) {
+                // if it is a part of current context - leave foreach
+                if (strpos($value, $namespace) !== false) {
+                    break;
+                }
+
+                // check case if typename is a part of namespace, and alias has another part
+                $_typeParts = explode(self::OPERATOR_NAMESPACE, $type);
+                if (count($_typeParts) > 2) {
+                    $_type = $_typeParts[0];
+                    if (strrpos($value, $_type) === strlen($value) - strlen($_type))
+                    {
+                        unset($_typeParts[0]);
+                        return new Fqsen(self::OPERATOR_NAMESPACE . $value . self::OPERATOR_NAMESPACE . implode(self::OPERATOR_NAMESPACE, $_typeParts));
+                    }
+                }
+
+                // if found alias
+                if (strrpos($value, $type) === strlen($value) - strlen($type)) {
+                    return new Fqsen(self::OPERATOR_NAMESPACE . $value);
+                }
+            }
+
             if ('' !== $namespace) {
                 $namespace .= self::OPERATOR_NAMESPACE;
             }


### PR DESCRIPTION
For example:

```php
<?php 
namespace somens;
use some\other\ns;
class A {
   public function(): ns
   {...}
}
```

`ns` will be resolved correctly as `some\other\ns` not `somens\ns`.

Such as

```php
<?php 
namespace somens;
use some\other;
class A {
   public function(): other\ns
   {...}
}
```

`ns` will be resolved correctly as `some\other\ns` not `somens\other\ns`.