### PR TITLE
Psalm: Enable totallyTyped=true and bump type coverage to 100%

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,10 @@
 parameters:
     level: max
-    checkGenericClassInNonGenericObjectType: false
-    checkMissingIterableValueType: false
+
+    ignoreErrors:
+        # Bug in PHPStan? The error is "expects A, A given"
+        - '#Parameter \#1 \$tokens of method phpDocumentor\\Reflection\\Types\\ContextFactory::parse#'
+        # ArrayIterator::current can return null if iterated even if ArrayIterator::valid isn't checked before
+        - '#Strict comparison using === between array\(int, string, int\)\|string and false will always evaluate to false#'
+        - '#Strict comparison using === between string and null will always evaluate to false#'
+        - '#Unreachable statement - code above always terminates#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
+    totallyTyped="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config file:///composer/vendor/vimeo/psalm/config.xsd"
@@ -13,6 +13,20 @@
     </projectFiles>
 
     <issueHandlers>
-        <LessSpecificReturnType errorLevel="info" />
+        <DocblockTypeContradiction>
+            <errorLevel type="info">
+                <!-- ArrayIterator::current can return null if iterated even if ArrayIterator::valid isn't checked before -->
+                <file name="src/TypeResolver.php"/>
+                <!-- Not sure what's going on. I don't think it's possible to have false here -->
+                <file name="src/Types/ContextFactory.php"/>
+            </errorLevel>
+        </DocblockTypeContradiction>
+        
+        <RedundantConditionGivenDocblockType>
+            <errorLevel type="info">
+                <!-- ArrayIterator::current can return null if iterated even if ArrayIterator::valid isn't checked before -->
+                <file name="src/TypeResolver.php"/>
+            </errorLevel>
+        </RedundantConditionGivenDocblockType>
     </issueHandlers>
 </psalm>

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -151,8 +151,8 @@ final class TypeResolver
     /**
      * Analyse each tokens and creates types
      *
-     * @param ArrayIterator $tokens        the iterator on tokens
-     * @param int           $parserContext on of self::PARSER_* constants, indicating
+     * @param ArrayIterator<int, string> $tokens        the iterator on tokens
+     * @param int                        $parserContext on of self::PARSER_* constants, indicating
      * the context where we are in the parsing
      */
     private function parseTypes(ArrayIterator $tokens, Context $context, int $parserContext) : Type
@@ -394,6 +394,8 @@ final class TypeResolver
 
     /**
      * Resolves class string
+     *
+     * @param ArrayIterator<int, string> $tokens
      */
     private function resolveClassString(ArrayIterator $tokens, Context $context) : Type
     {
@@ -424,6 +426,8 @@ final class TypeResolver
 
     /**
      * Resolves the collection values and keys
+     *
+     * @param ArrayIterator<int, string> $tokens
      *
      * @return Array_|Iterable_|Collection
      */

--- a/src/Types/Compound.php
+++ b/src/Types/Compound.php
@@ -24,16 +24,20 @@ use function implode;
  * A Compound Type is not so much a special keyword or object reference but is a series of Types that are separated
  * using an OR operator (`|`). This combination of types signifies that whatever is associated with this compound type
  * may contain a value with any of the given types.
+ *
+ * @template-implements IteratorAggregate<int, Type>
  */
 final class Compound implements Type, IteratorAggregate
 {
-    /** @var Type[] */
+    /** @var array<int, Type> */
     private $types = [];
 
     /**
      * Initializes a compound type (i.e. `string|int`) and tests if the provided types all implement the Type interface.
      *
      * @param Type[] $types
+     *
+     * @phpstan-param list<Type> $types
      */
     public function __construct(array $types)
     {
@@ -86,9 +90,9 @@ final class Compound implements Type, IteratorAggregate
     }
 
     /**
-     * {@inheritdoc}
+     * @return ArrayIterator<int, Type>
      */
-    public function getIterator()
+    public function getIterator() : ArrayIterator
     {
         return new ArrayIterator($this->types);
     }

--- a/src/Types/ContextFactory.php
+++ b/src/Types/ContextFactory.php
@@ -64,6 +64,7 @@ final class ContextFactory
     public function createFromReflector(Reflector $reflector) : Context
     {
         if ($reflector instanceof ReflectionClass) {
+            /** @var ReflectionClass<object> $reflector */
             return $this->createFromReflectionClass($reflector);
         }
 
@@ -90,6 +91,7 @@ final class ContextFactory
     {
         $class = $parameter->getDeclaringClass();
         if ($class) {
+            /** @var ReflectionClass<object> $class */
             return $this->createFromReflectionClass($class);
         }
 
@@ -111,6 +113,9 @@ final class ContextFactory
         return $this->createFromReflectionClass($constant->getDeclaringClass());
     }
 
+    /**
+     * @param ReflectionClass<object> $class
+     */
     private function createFromReflectionClass(ReflectionClass $class) : Context
     {
         $fileName  = $class->getFileName();
@@ -188,6 +193,8 @@ final class ContextFactory
 
     /**
      * Deduce the name from tokens when we are at the T_NAMESPACE token.
+     *
+     * @param ArrayIterator<int, string|array{0:int,1:string,2:int}> $tokens
      */
     private function parseNamespace(ArrayIterator $tokens) : string
     {
@@ -206,6 +213,8 @@ final class ContextFactory
 
     /**
      * Deduce the names of all imports when we are at the T_USE token.
+     *
+     * @param ArrayIterator<int, string|array{0:int,1:string,2:int}> $tokens
      *
      * @return string[]
      */
@@ -231,6 +240,8 @@ final class ContextFactory
 
     /**
      * Fast-forwards the iterator as longs as we don't encounter a T_STRING or T_NS_SEPARATOR token.
+     *
+     * @param ArrayIterator<int, string|array{0:int,1:string,2:int}> $tokens
      */
     private function skipToNextStringOrNamespaceSeparator(ArrayIterator $tokens) : void
     {
@@ -242,6 +253,8 @@ final class ContextFactory
     /**
      * Deduce the namespace name and alias of an import when we are at the T_USE token or have not reached the end of
      * a USE statement yet. This will return a key/value array of the alias => namespace.
+     *
+     * @param ArrayIterator<int, string|array{0:int,1:string,2:int}> $tokens
      *
      * @return string[]
      *
@@ -264,7 +277,7 @@ final class ContextFactory
                     switch ($tokenId) {
                         case T_STRING:
                         case T_NS_SEPARATOR:
-                            $currentNs   .= $tokenValue;
+                            $currentNs   .= (string) $tokenValue;
                             $currentAlias =  $tokenValue;
                             break;
                         case T_CURLY_OPEN:
@@ -300,17 +313,17 @@ final class ContextFactory
                     switch ($tokenId) {
                         case T_STRING:
                         case T_NS_SEPARATOR:
-                            $currentNs   .= $tokenValue;
+                            $currentNs   .= (string) $tokenValue;
                             $currentAlias = $tokenValue;
                             break;
                         case T_AS:
                             $state = 'grouped-alias';
                             break;
                         case self::T_LITERAL_USE_SEPARATOR:
-                            $state                                 = 'grouped';
-                            $extractedUseStatements[$currentAlias] = $currentNs;
-                            $currentNs                             = $groupedNs;
-                            $currentAlias                          = '';
+                            $state                                          = 'grouped';
+                            $extractedUseStatements[(string) $currentAlias] = $currentNs;
+                            $currentNs                                      = $groupedNs;
+                            $currentAlias                                   = '';
                             break;
                         case self::T_LITERAL_END_OF_USE:
                             $state = 'end';
@@ -325,10 +338,10 @@ final class ContextFactory
                             $currentAlias = $tokenValue;
                             break;
                         case self::T_LITERAL_USE_SEPARATOR:
-                            $state                                 = 'grouped';
-                            $extractedUseStatements[$currentAlias] = $currentNs;
-                            $currentNs                             = $groupedNs;
-                            $currentAlias                          = '';
+                            $state                                          = 'grouped';
+                            $extractedUseStatements[(string) $currentAlias] = $currentNs;
+                            $currentNs                                      = $groupedNs;
+                            $currentAlias                                   = '';
                             break;
                         case self::T_LITERAL_END_OF_USE:
                             $state = 'end';
@@ -346,7 +359,7 @@ final class ContextFactory
         }
 
         if ($groupedNs !== $currentNs) {
-            $extractedUseStatements[$currentAlias] = $currentNs;
+            $extractedUseStatements[(string) $currentAlias] = $currentNs;
         }
 
         return $extractedUseStatements;


### PR DESCRIPTION
This PR enforce a little more checks with Psalm

I had to ignore three errors. Two have the same cause: the library doesn't always check ArrayIterator::valid() before calling ArrayIterator::current so it can get a null value. This is not expected by Psalm. It's sort of false positive but caused by a bad practice...

The third I think is legitimate but I didn't take the time to prove it so I'll ignore it for now.