### PR TITLE
fix array-offset via "isset"-call

### DIFF
--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -239,7 +239,7 @@ final class TypeResolver
                 $resolvedType = new Expression($type);
 
                 $types[] = $resolvedType;
-            } elseif ($parserContext === self::PARSER_IN_ARRAY_EXPRESSION && $token[0] === ')') {
+            } elseif ($parserContext === self::PARSER_IN_ARRAY_EXPRESSION && isset($token[0]) && $token[0] === ')') {
                 break;
             } elseif ($token === '<') {
                 if (count($types) === 0) {
@@ -406,7 +406,7 @@ final class TypeResolver
      */
     private function isPartialStructuralElementName(string $type): bool
     {
-        return ($type[0] !== self::OPERATOR_NAMESPACE) && !$this->isKeyword($type);
+        return (isset($type[0]) && $type[0] !== self::OPERATOR_NAMESPACE) && !$this->isKeyword($type);
     }
 
     /**


### PR DESCRIPTION
I saw that error in ```isPartialStructuralElementName``` while parsing all /vendor/* stuff for testing reasons. And I found the second ```isset($token[0])``` call only because I was searching for "[0]" in the code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpdocumentor/typeresolver/104)
<!-- Reviewable:end -->
