### PR TITLE
Tests/ArrayKeyTest: fix incorrect `@uses` tag

### DIFF
--- a/tests/unit/Types/ArrayKeyTest.php
+++ b/tests/unit/Types/ArrayKeyTest.php
@@ -30,7 +30,7 @@ final class ArrayKeyTest extends TestCase
     }
 
     /**
-     * @uses ::__construct
+     * @uses \phpDocumentor\Reflection\Types\ArrayKey::__construct
      *
      * @covers ::getIterator
      */


### PR DESCRIPTION
This tag was flagged by PHPUnit:
```
1) phpDocumentor\Reflection\Types\ArrayKeyTest::testArrayKeyCanBeIterated
Trying to @cover or @use not existing method "::__construct".
```

Fixed now.