### PR TITLE
CS update after upstream changes

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,21 +1,35 @@
 <?xml version="1.0"?>
-<ruleset name="phpDocumentor">
-    <description>The coding standard for phpDocumentor.</description>
+<ruleset name="TypeResolver">
+    <description>The coding standard for this library.</description>
 
     <file>src</file>
     <file>tests/unit</file>
-    <exclude-pattern>*/tests/unit/Types/ContextFactoryTest.php</exclude-pattern>
+    <exclude-pattern>*/tests/unit/Types/ContextFactoryTest\.php</exclude-pattern>
     <arg value="p"/>
 
+    <!-- Set the minimum PHP version for PHPCompatibility.
+         This should be kept in sync with the requirements in the composer.json file. -->
+    <config name="testVersion" value="7.2-"/>
+
     <rule ref="phpDocumentor">
+        <!-- Property type declarations are a PHP 7.4 feature. -->
+        <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingNativeTypeHint"/>
     </rule>
 
     <rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming.SuperfluousPrefix">
-        <exclude-pattern>*/src/*/Abstract*.php</exclude-pattern>
+        <exclude-pattern>*/src/*/Abstract*\.php</exclude-pattern>
     </rule>
 
     <rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
-        <exclude-pattern>*/src/PseudoTypes/False_.php</exclude-pattern>
-        <exclude-pattern>*/src/PseudoTypes/True_.php</exclude-pattern>
+        <exclude-pattern>*/src/PseudoTypes/False_\.php</exclude-pattern>
+        <exclude-pattern>*/src/PseudoTypes/True_\.php</exclude-pattern>
+    </rule>
+
+	<!-- Ignore two PHP 8.0 constants which are being polyfilled in the file using them. -->
+    <rule ref="PHPCompatibility.Constants.NewConstants.t_name_qualifiedFound">
+        <exclude-pattern>*/src/Types/ContextFactory\.php</exclude-pattern>
+    </rule>
+    <rule ref="PHPCompatibility.Constants.NewConstants.t_name_fully_qualifiedFound">
+        <exclude-pattern>*/src/Types/ContextFactory\.php</exclude-pattern>
     </rule>
 </ruleset>

--- a/src/FqsenResolver.php
+++ b/src/FqsenResolver.php
@@ -29,7 +29,7 @@ class FqsenResolver
     /** @var string Definition of the NAMESPACE operator in PHP */
     private const OPERATOR_NAMESPACE = '\\';
 
-    public function resolve(string $fqsen, ?Context $context = null) : Fqsen
+    public function resolve(string $fqsen, ?Context $context = null): Fqsen
     {
         if ($context === null) {
             $context = new Context('');
@@ -45,7 +45,7 @@ class FqsenResolver
     /**
      * Tests whether the given type is a Fully Qualified Structural Element Name.
      */
-    private function isFqsen(string $type) : bool
+    private function isFqsen(string $type): bool
     {
         return strpos($type, self::OPERATOR_NAMESPACE) === 0;
     }
@@ -56,7 +56,7 @@ class FqsenResolver
      *
      * @throws InvalidArgumentException When type is not a valid FQSEN.
      */
-    private function resolvePartialStructuralElementName(string $type, Context $context) : Fqsen
+    private function resolvePartialStructuralElementName(string $type, Context $context): Fqsen
     {
         $typeParts = explode(self::OPERATOR_NAMESPACE, $type, 2);
 

--- a/src/FqsenResolver.php
+++ b/src/FqsenResolver.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Reflection;
 
 use InvalidArgumentException;
 use phpDocumentor\Reflection\Types\Context;
+
 use function explode;
 use function implode;
 use function strpos;

--- a/src/PseudoType.php
+++ b/src/PseudoType.php
@@ -15,5 +15,5 @@ namespace phpDocumentor\Reflection;
 
 interface PseudoType extends Type
 {
-    public function underlyingType() : Type;
+    public function underlyingType(): Type;
 }

--- a/src/PseudoTypes/CallableString.php
+++ b/src/PseudoTypes/CallableString.php
@@ -24,7 +24,7 @@ use phpDocumentor\Reflection\Types\String_;
  */
 final class CallableString extends String_ implements PseudoType
 {
-    public function underlyingType() : Type
+    public function underlyingType(): Type
     {
         return new String_();
     }
@@ -32,7 +32,7 @@ final class CallableString extends String_ implements PseudoType
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'callable-string';
     }

--- a/src/PseudoTypes/False_.php
+++ b/src/PseudoTypes/False_.php
@@ -25,12 +25,12 @@ use function class_alias;
  */
 final class False_ extends Boolean implements PseudoType
 {
-    public function underlyingType() : Type
+    public function underlyingType(): Type
     {
         return new Boolean();
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'false';
     }

--- a/src/PseudoTypes/False_.php
+++ b/src/PseudoTypes/False_.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Reflection\PseudoTypes;
 use phpDocumentor\Reflection\PseudoType;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Boolean;
+
 use function class_alias;
 
 /**

--- a/src/PseudoTypes/HtmlEscapedString.php
+++ b/src/PseudoTypes/HtmlEscapedString.php
@@ -24,7 +24,7 @@ use phpDocumentor\Reflection\Types\String_;
  */
 final class HtmlEscapedString extends String_ implements PseudoType
 {
-    public function underlyingType() : Type
+    public function underlyingType(): Type
     {
         return new String_();
     }
@@ -32,7 +32,7 @@ final class HtmlEscapedString extends String_ implements PseudoType
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'html-escaped-string';
     }

--- a/src/PseudoTypes/LowercaseString.php
+++ b/src/PseudoTypes/LowercaseString.php
@@ -24,7 +24,7 @@ use phpDocumentor\Reflection\Types\String_;
  */
 final class LowercaseString extends String_ implements PseudoType
 {
-    public function underlyingType() : Type
+    public function underlyingType(): Type
     {
         return new String_();
     }
@@ -32,7 +32,7 @@ final class LowercaseString extends String_ implements PseudoType
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'lowercase-string';
     }

--- a/src/PseudoTypes/NonEmptyLowercaseString.php
+++ b/src/PseudoTypes/NonEmptyLowercaseString.php
@@ -24,7 +24,7 @@ use phpDocumentor\Reflection\Types\String_;
  */
 final class NonEmptyLowercaseString extends String_ implements PseudoType
 {
-    public function underlyingType() : Type
+    public function underlyingType(): Type
     {
         return new String_();
     }
@@ -32,7 +32,7 @@ final class NonEmptyLowercaseString extends String_ implements PseudoType
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'non-empty-lowercase-string';
     }

--- a/src/PseudoTypes/NonEmptyString.php
+++ b/src/PseudoTypes/NonEmptyString.php
@@ -24,7 +24,7 @@ use phpDocumentor\Reflection\Types\String_;
  */
 final class NonEmptyString extends String_ implements PseudoType
 {
-    public function underlyingType() : Type
+    public function underlyingType(): Type
     {
         return new String_();
     }
@@ -32,7 +32,7 @@ final class NonEmptyString extends String_ implements PseudoType
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'non-empty-string';
     }

--- a/src/PseudoTypes/NumericString.php
+++ b/src/PseudoTypes/NumericString.php
@@ -24,7 +24,7 @@ use phpDocumentor\Reflection\Types\String_;
  */
 final class NumericString extends String_ implements PseudoType
 {
-    public function underlyingType() : Type
+    public function underlyingType(): Type
     {
         return new String_();
     }
@@ -32,7 +32,7 @@ final class NumericString extends String_ implements PseudoType
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'numeric-string';
     }

--- a/src/PseudoTypes/PositiveInteger.php
+++ b/src/PseudoTypes/PositiveInteger.php
@@ -24,7 +24,7 @@ use phpDocumentor\Reflection\Types\Integer;
  */
 final class PositiveInteger extends Integer implements PseudoType
 {
-    public function underlyingType() : Type
+    public function underlyingType(): Type
     {
         return new Integer();
     }
@@ -32,7 +32,7 @@ final class PositiveInteger extends Integer implements PseudoType
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'positive-int';
     }

--- a/src/PseudoTypes/TraitString.php
+++ b/src/PseudoTypes/TraitString.php
@@ -24,7 +24,7 @@ use phpDocumentor\Reflection\Types\String_;
  */
 final class TraitString extends String_ implements PseudoType
 {
-    public function underlyingType() : Type
+    public function underlyingType(): Type
     {
         return new String_();
     }
@@ -32,7 +32,7 @@ final class TraitString extends String_ implements PseudoType
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'trait-string';
     }

--- a/src/PseudoTypes/True_.php
+++ b/src/PseudoTypes/True_.php
@@ -25,12 +25,12 @@ use function class_alias;
  */
 final class True_ extends Boolean implements PseudoType
 {
-    public function underlyingType() : Type
+    public function underlyingType(): Type
     {
         return new Boolean();
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'true';
     }

--- a/src/PseudoTypes/True_.php
+++ b/src/PseudoTypes/True_.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Reflection\PseudoTypes;
 use phpDocumentor\Reflection\PseudoType;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Boolean;
+
 use function class_alias;
 
 /**

--- a/src/Type.php
+++ b/src/Type.php
@@ -21,5 +21,5 @@ interface Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string;
+    public function __toString(): string;
 }

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -137,7 +137,7 @@ final class TypeResolver
      *
      * @param string $type The relative or absolute type.
      */
-    public function resolve(string $type, ?Context $context = null) : Type
+    public function resolve(string $type, ?Context $context = null): Type
     {
         $type = trim($type);
         if (!$type) {
@@ -173,7 +173,7 @@ final class TypeResolver
      * @param int                        $parserContext on of self::PARSER_* constants, indicating
      * the context where we are in the parsing
      */
-    private function parseTypes(ArrayIterator $tokens, Context $context, int $parserContext) : Type
+    private function parseTypes(ArrayIterator $tokens, Context $context, int $parserContext): Type
     {
         $types = [];
         $token = '';
@@ -326,7 +326,7 @@ final class TypeResolver
      *
      * @psalm-mutation-free
      */
-    private function resolveSingleType(string $type, Context $context) : object
+    private function resolveSingleType(string $type, Context $context): object
     {
         switch (true) {
             case $this->isKeyword($type):
@@ -352,7 +352,7 @@ final class TypeResolver
      *
      * @psalm-param class-string<Type> $typeClassName
      */
-    public function addKeyword(string $keyword, string $typeClassName) : void
+    public function addKeyword(string $keyword, string $typeClassName): void
     {
         if (!class_exists($typeClassName)) {
             throw new InvalidArgumentException(
@@ -385,7 +385,7 @@ final class TypeResolver
      *
      * @psalm-mutation-free
      */
-    private function isKeyword(string $type) : bool
+    private function isKeyword(string $type): bool
     {
         return array_key_exists(strtolower($type), $this->keywords);
     }
@@ -397,7 +397,7 @@ final class TypeResolver
      *
      * @psalm-mutation-free
      */
-    private function isPartialStructuralElementName(string $type) : bool
+    private function isPartialStructuralElementName(string $type): bool
     {
         return ($type[0] !== self::OPERATOR_NAMESPACE) && !$this->isKeyword($type);
     }
@@ -407,7 +407,7 @@ final class TypeResolver
      *
      * @psalm-mutation-free
      */
-    private function isFqsen(string $type) : bool
+    private function isFqsen(string $type): bool
     {
         return strpos($type, self::OPERATOR_NAMESPACE) === 0;
     }
@@ -417,7 +417,7 @@ final class TypeResolver
      *
      * @psalm-mutation-free
      */
-    private function resolveKeyword(string $type) : Type
+    private function resolveKeyword(string $type): Type
     {
         $className = $this->keywords[strtolower($type)];
 
@@ -429,7 +429,7 @@ final class TypeResolver
      *
      * @psalm-mutation-free
      */
-    private function resolveTypedObject(string $type, ?Context $context = null) : Object_
+    private function resolveTypedObject(string $type, ?Context $context = null): Object_
     {
         return new Object_($this->fqsenResolver->resolve($type, $context));
     }
@@ -439,7 +439,7 @@ final class TypeResolver
      *
      * @param ArrayIterator<int, (string|null)> $tokens
      */
-    private function resolveClassString(ArrayIterator $tokens, Context $context) : Type
+    private function resolveClassString(ArrayIterator $tokens, Context $context): Type
     {
         $tokens->next();
 
@@ -472,7 +472,7 @@ final class TypeResolver
      *
      * @param ArrayIterator<int, (string|null)> $tokens
      */
-    private function resolveInterfaceString(ArrayIterator $tokens, Context $context) : Type
+    private function resolveInterfaceString(ArrayIterator $tokens, Context $context): Type
     {
         $tokens->next();
 
@@ -507,7 +507,7 @@ final class TypeResolver
      *
      * @return Array_|Iterable_|Collection
      */
-    private function resolveCollection(ArrayIterator $tokens, Type $classType, Context $context) : Type
+    private function resolveCollection(ArrayIterator $tokens, Type $classType, Context $context): Type
     {
         $isArray    = ((string) $classType === 'array');
         $isIterable = ((string) $classType === 'iterable');
@@ -590,7 +590,7 @@ final class TypeResolver
     /**
      * @psalm-pure
      */
-    private function makeCollectionFromObject(Object_ $object, Type $valueType, ?Type $keyType = null) : Collection
+    private function makeCollectionFromObject(Object_ $object, Type $valueType, ?Type $keyType = null): Collection
     {
         return new Collection($object->getFqsen(), $valueType, $keyType);
     }

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -29,6 +29,7 @@ use phpDocumentor\Reflection\Types\Nullable;
 use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\String_;
 use RuntimeException;
+
 use function array_key_exists;
 use function array_pop;
 use function array_values;
@@ -42,6 +43,7 @@ use function preg_split;
 use function strpos;
 use function strtolower;
 use function trim;
+
 use const PREG_SPLIT_DELIM_CAPTURE;
 use const PREG_SPLIT_NO_EMPTY;
 

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -195,11 +195,12 @@ final class TypeResolver
                     );
                 }
 
-                if (!in_array($parserContext, [
-                    self::PARSER_IN_COMPOUND,
-                    self::PARSER_IN_ARRAY_EXPRESSION,
-                    self::PARSER_IN_COLLECTION_EXPRESSION,
-                ], true)
+                if (
+                    !in_array($parserContext, [
+                        self::PARSER_IN_COMPOUND,
+                        self::PARSER_IN_ARRAY_EXPRESSION,
+                        self::PARSER_IN_COLLECTION_EXPRESSION,
+                    ], true)
                 ) {
                     throw new RuntimeException(
                         'Unexpected type separator'
@@ -209,11 +210,12 @@ final class TypeResolver
                 $compoundToken = $token;
                 $tokens->next();
             } elseif ($token === '?') {
-                if (!in_array($parserContext, [
-                    self::PARSER_IN_COMPOUND,
-                    self::PARSER_IN_ARRAY_EXPRESSION,
-                    self::PARSER_IN_COLLECTION_EXPRESSION,
-                ], true)
+                if (
+                    !in_array($parserContext, [
+                        self::PARSER_IN_COMPOUND,
+                        self::PARSER_IN_ARRAY_EXPRESSION,
+                        self::PARSER_IN_COLLECTION_EXPRESSION,
+                    ], true)
                 ) {
                     throw new RuntimeException(
                         'Unexpected nullable character'
@@ -258,7 +260,8 @@ final class TypeResolver
                 }
 
                 $tokens->next();
-            } elseif ($parserContext === self::PARSER_IN_COLLECTION_EXPRESSION
+            } elseif (
+                $parserContext === self::PARSER_IN_COLLECTION_EXPRESSION
                 && ($token === '>' || trim($token) === ',')
             ) {
                 break;
@@ -333,8 +336,10 @@ final class TypeResolver
         switch (true) {
             case $this->isKeyword($type):
                 return $this->resolveKeyword($type);
+
             case $this->isFqsen($type):
                 return $this->resolveTypedObject($type);
+
             case $this->isPartialStructuralElementName($type):
                 return $this->resolveTypedObject($type, $context);
 
@@ -515,8 +520,10 @@ final class TypeResolver
         $isIterable = ((string) $classType === 'iterable');
 
         // allow only "array", "iterable" or class name before "<"
-        if (!$isArray && !$isIterable
-            && (!$classType instanceof Object_ || $classType->getFqsen() === null)) {
+        if (
+            !$isArray && !$isIterable
+            && (!$classType instanceof Object_ || $classType->getFqsen() === null)
+        ) {
             throw new RuntimeException(
                 $classType . ' is not a collection'
             );
@@ -534,7 +541,8 @@ final class TypeResolver
             if ($isArray) {
                 // check the key type for an "array" collection. We allow only
                 // strings or integers.
-                if (!$keyType instanceof String_ &&
+                if (
+                    !$keyType instanceof String_ &&
                     !$keyType instanceof Integer &&
                     !$keyType instanceof Compound
                 ) {
@@ -545,7 +553,8 @@ final class TypeResolver
 
                 if ($keyType instanceof Compound) {
                     foreach ($keyType->getIterator() as $item) {
-                        if (!$item instanceof String_ &&
+                        if (
+                            !$item instanceof String_ &&
                             !$item instanceof Integer
                         ) {
                             throw new RuntimeException(

--- a/src/Types/AbstractList.php
+++ b/src/Types/AbstractList.php
@@ -48,7 +48,7 @@ abstract class AbstractList implements Type
     /**
      * Returns the type for the keys of this array.
      */
-    public function getKeyType() : Type
+    public function getKeyType(): Type
     {
         return $this->keyType ?? $this->defaultKeyType;
     }
@@ -56,7 +56,7 @@ abstract class AbstractList implements Type
     /**
      * Returns the value for the keys of this array.
      */
-    public function getValueType() : Type
+    public function getValueType(): Type
     {
         return $this->valueType;
     }
@@ -64,7 +64,7 @@ abstract class AbstractList implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->keyType) {
             return 'array<' . $this->keyType . ',' . $this->valueType . '>';

--- a/src/Types/AggregatedType.php
+++ b/src/Types/AggregatedType.php
@@ -53,7 +53,7 @@ abstract class AggregatedType implements Type, IteratorAggregate
     /**
      * Returns the type at the given index.
      */
-    public function get(int $index) : ?Type
+    public function get(int $index): ?Type
     {
         if (!$this->has($index)) {
             return null;
@@ -65,7 +65,7 @@ abstract class AggregatedType implements Type, IteratorAggregate
     /**
      * Tests if this compound type has a type with the given index.
      */
-    public function has(int $index) : bool
+    public function has(int $index): bool
     {
         return array_key_exists($index, $this->types);
     }
@@ -73,7 +73,7 @@ abstract class AggregatedType implements Type, IteratorAggregate
     /**
      * Tests if this compound type contains the given type.
      */
-    public function contains(Type $type) : bool
+    public function contains(Type $type): bool
     {
         foreach ($this->types as $typePart) {
             // if the type is duplicate; do not add it
@@ -88,7 +88,7 @@ abstract class AggregatedType implements Type, IteratorAggregate
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return implode($this->token, $this->types);
     }
@@ -96,7 +96,7 @@ abstract class AggregatedType implements Type, IteratorAggregate
     /**
      * @return ArrayIterator<int, Type>
      */
-    public function getIterator() : ArrayIterator
+    public function getIterator(): ArrayIterator
     {
         return new ArrayIterator($this->types);
     }
@@ -104,7 +104,7 @@ abstract class AggregatedType implements Type, IteratorAggregate
     /**
      * @psalm-suppress ImpureMethodCall
      */
-    private function add(Type $type) : void
+    private function add(Type $type): void
     {
         if ($type instanceof self) {
             foreach ($type->getIterator() as $subType) {

--- a/src/Types/AggregatedType.php
+++ b/src/Types/AggregatedType.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Reflection\Types;
 use ArrayIterator;
 use IteratorAggregate;
 use phpDocumentor\Reflection\Type;
+
 use function array_key_exists;
 use function implode;
 

--- a/src/Types/ArrayKey.php
+++ b/src/Types/ArrayKey.php
@@ -27,7 +27,7 @@ final class ArrayKey extends AggregatedType
         parent::__construct([new String_(), new Integer()], '|');
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'array-key';
     }

--- a/src/Types/Boolean.php
+++ b/src/Types/Boolean.php
@@ -25,7 +25,7 @@ class Boolean implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'bool';
     }

--- a/src/Types/Callable_.php
+++ b/src/Types/Callable_.php
@@ -25,7 +25,7 @@ final class Callable_ implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'callable';
     }

--- a/src/Types/ClassString.php
+++ b/src/Types/ClassString.php
@@ -37,7 +37,7 @@ final class ClassString implements Type
     /**
      * Returns the FQSEN associated with this object.
      */
-    public function getFqsen() : ?Fqsen
+    public function getFqsen(): ?Fqsen
     {
         return $this->fqsen;
     }
@@ -45,7 +45,7 @@ final class ClassString implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->fqsen === null) {
             return 'class-string';

--- a/src/Types/Collection.php
+++ b/src/Types/Collection.php
@@ -47,7 +47,7 @@ final class Collection extends AbstractList
     /**
      * Returns the FQSEN associated with this object.
      */
-    public function getFqsen() : ?Fqsen
+    public function getFqsen(): ?Fqsen
     {
         return $this->fqsen;
     }
@@ -55,7 +55,7 @@ final class Collection extends AbstractList
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         $objectType = (string) ($this->fqsen ?? 'object');
 

--- a/src/Types/Context.php
+++ b/src/Types/Context.php
@@ -50,7 +50,6 @@ final class Context
      *
      * @param string   $namespace        The namespace where this DocBlock resides in.
      * @param string[] $namespaceAliases List of namespace aliases => Fully Qualified Namespace.
-     *
      * @psalm-param array<string, string> $namespaceAliases
      */
     public function __construct(string $namespace, array $namespaceAliases = [])
@@ -87,7 +86,6 @@ final class Context
      * the alias for the imported Namespace.
      *
      * @return string[]
-     *
      * @psalm-return array<string, string>
      */
     public function getNamespaceAliases(): array

--- a/src/Types/Context.php
+++ b/src/Types/Context.php
@@ -77,7 +77,7 @@ final class Context
     /**
      * Returns the Qualified Namespace Name (thus without `\` in front) where the associated element is in.
      */
-    public function getNamespace() : string
+    public function getNamespace(): string
     {
         return $this->namespace;
     }
@@ -90,7 +90,7 @@ final class Context
      *
      * @psalm-return array<string, string>
      */
-    public function getNamespaceAliases() : array
+    public function getNamespaceAliases(): array
     {
         return $this->namespaceAliases;
     }

--- a/src/Types/ContextFactory.php
+++ b/src/Types/ContextFactory.php
@@ -73,7 +73,7 @@ final class ContextFactory
      *
      * @see Context for more information on Contexts.
      */
-    public function createFromReflector(Reflector $reflector) : Context
+    public function createFromReflector(Reflector $reflector): Context
     {
         if ($reflector instanceof ReflectionClass) {
             //phpcs:ignore SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable
@@ -101,7 +101,7 @@ final class ContextFactory
         throw new UnexpectedValueException('Unhandled \Reflector instance given:  ' . get_class($reflector));
     }
 
-    private function createFromReflectionParameter(ReflectionParameter $parameter) : Context
+    private function createFromReflectionParameter(ReflectionParameter $parameter): Context
     {
         $class = $parameter->getDeclaringClass();
         if (!$class) {
@@ -111,21 +111,21 @@ final class ContextFactory
         return $this->createFromReflectionClass($class);
     }
 
-    private function createFromReflectionMethod(ReflectionMethod $method) : Context
+    private function createFromReflectionMethod(ReflectionMethod $method): Context
     {
         $class = $method->getDeclaringClass();
 
         return $this->createFromReflectionClass($class);
     }
 
-    private function createFromReflectionProperty(ReflectionProperty $property) : Context
+    private function createFromReflectionProperty(ReflectionProperty $property): Context
     {
         $class = $property->getDeclaringClass();
 
         return $this->createFromReflectionClass($class);
     }
 
-    private function createFromReflectionClassConstant(ReflectionClassConstant $constant) : Context
+    private function createFromReflectionClassConstant(ReflectionClassConstant $constant): Context
     {
         //phpcs:ignore SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration.MissingVariable
         /** @phpstan-var ReflectionClass<object> $class */
@@ -137,7 +137,7 @@ final class ContextFactory
     /**
      * @phpstan-param ReflectionClass<object> $class
      */
-    private function createFromReflectionClass(ReflectionClass $class) : Context
+    private function createFromReflectionClass(ReflectionClass $class): Context
     {
         $fileName  = $class->getFileName();
         $namespace = $class->getNamespaceName();
@@ -163,7 +163,7 @@ final class ContextFactory
      * this method first normalizes.
      * @param string $fileContents The file's contents to retrieve the aliases from with the given namespace.
      */
-    public function createForNamespace(string $namespace, string $fileContents) : Context
+    public function createForNamespace(string $namespace, string $fileContents): Context
     {
         $namespace        = trim($namespace, '\\');
         $useStatements    = [];
@@ -220,7 +220,7 @@ final class ContextFactory
      *
      * @param ArrayIterator<int, string|array{0:int,1:string,2:int}> $tokens
      */
-    private function parseNamespace(ArrayIterator $tokens) : string
+    private function parseNamespace(ArrayIterator $tokens): string
     {
         // skip to the first string or namespace separator
         $this->skipToNextStringOrNamespaceSeparator($tokens);
@@ -244,7 +244,7 @@ final class ContextFactory
      *
      * @psalm-return array<string, string>
      */
-    private function parseUseStatement(ArrayIterator $tokens) : array
+    private function parseUseStatement(ArrayIterator $tokens): array
     {
         $uses = [];
 
@@ -266,7 +266,7 @@ final class ContextFactory
      *
      * @param ArrayIterator<int, string|array{0:int,1:string,2:int}> $tokens
      */
-    private function skipToNextStringOrNamespaceSeparator(ArrayIterator $tokens) : void
+    private function skipToNextStringOrNamespaceSeparator(ArrayIterator $tokens): void
     {
         while ($tokens->valid()) {
             $currentToken = $tokens->current();
@@ -298,7 +298,7 @@ final class ContextFactory
      *
      * @psalm-return array<string, string>
      */
-    private function extractUseStatements(ArrayIterator $tokens) : array
+    private function extractUseStatements(ArrayIterator $tokens): array
     {
         $extractedUseStatements = [];
         $groupedNs              = '';

--- a/src/Types/ContextFactory.php
+++ b/src/Types/ContextFactory.php
@@ -23,6 +23,7 @@ use ReflectionProperty;
 use Reflector;
 use RuntimeException;
 use UnexpectedValueException;
+
 use function define;
 use function defined;
 use function file_exists;
@@ -34,6 +35,7 @@ use function strrpos;
 use function substr;
 use function token_get_all;
 use function trim;
+
 use const T_AS;
 use const T_CLASS;
 use const T_CURLY_OPEN;

--- a/src/Types/ContextFactory.php
+++ b/src/Types/ContextFactory.php
@@ -188,8 +188,10 @@ final class ContextFactory
                     $firstBraceFound = false;
                     while ($tokens->valid() && ($braceLevel > 0 || !$firstBraceFound)) {
                         $currentToken = $tokens->current();
-                        if ($currentToken === '{'
-                            || in_array($currentToken[0], [T_CURLY_OPEN, T_DOLLAR_OPEN_CURLY_BRACES], true)) {
+                        if (
+                            $currentToken === '{'
+                            || in_array($currentToken[0], [T_CURLY_OPEN, T_DOLLAR_OPEN_CURLY_BRACES], true)
+                        ) {
                             if (!$firstBraceFound) {
                                 $firstBraceFound = true;
                             }

--- a/src/Types/ContextFactory.php
+++ b/src/Types/ContextFactory.php
@@ -40,6 +40,8 @@ use const T_AS;
 use const T_CLASS;
 use const T_CURLY_OPEN;
 use const T_DOLLAR_OPEN_CURLY_BRACES;
+use const T_NAME_FULLY_QUALIFIED;
+use const T_NAME_QUALIFIED;
 use const T_NAMESPACE;
 use const T_NS_SEPARATOR;
 use const T_STRING;

--- a/src/Types/ContextFactory.php
+++ b/src/Types/ContextFactory.php
@@ -247,7 +247,6 @@ final class ContextFactory
      * @param ArrayIterator<int, string|array{0:int,1:string,2:int}> $tokens
      *
      * @return string[]
-     *
      * @psalm-return array<string, string>
      */
     private function parseUseStatement(ArrayIterator $tokens): array
@@ -299,10 +298,9 @@ final class ContextFactory
      * @param ArrayIterator<int, string|array{0:int,1:string,2:int}> $tokens
      *
      * @return string[]
+     * @psalm-return array<string, string>
      *
      * @psalm-suppress TypeDoesNotContainType
-     *
-     * @psalm-return array<string, string>
      */
     private function extractUseStatements(ArrayIterator $tokens): array
     {

--- a/src/Types/Expression.php
+++ b/src/Types/Expression.php
@@ -36,7 +36,7 @@ final class Expression implements Type
     /**
      * Returns the value for the keys of this array.
      */
-    public function getValueType() : Type
+    public function getValueType(): Type
     {
         return $this->valueType;
     }
@@ -44,7 +44,7 @@ final class Expression implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return '(' . $this->valueType . ')';
     }

--- a/src/Types/Float_.php
+++ b/src/Types/Float_.php
@@ -25,7 +25,7 @@ final class Float_ implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'float';
     }

--- a/src/Types/Integer.php
+++ b/src/Types/Integer.php
@@ -25,7 +25,7 @@ class Integer implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'int';
     }

--- a/src/Types/InterfaceString.php
+++ b/src/Types/InterfaceString.php
@@ -37,7 +37,7 @@ final class InterfaceString implements Type
     /**
      * Returns the FQSEN associated with this object.
      */
-    public function getFqsen() : ?Fqsen
+    public function getFqsen(): ?Fqsen
     {
         return $this->fqsen;
     }
@@ -45,7 +45,7 @@ final class InterfaceString implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->fqsen === null) {
             return 'interface-string';

--- a/src/Types/Iterable_.php
+++ b/src/Types/Iterable_.php
@@ -23,7 +23,7 @@ final class Iterable_ extends AbstractList
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->keyType) {
             return 'iterable<' . $this->keyType . ',' . $this->valueType . '>';

--- a/src/Types/Mixed_.php
+++ b/src/Types/Mixed_.php
@@ -25,7 +25,7 @@ final class Mixed_ implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'mixed';
     }

--- a/src/Types/Null_.php
+++ b/src/Types/Null_.php
@@ -25,7 +25,7 @@ final class Null_ implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'null';
     }

--- a/src/Types/Nullable.php
+++ b/src/Types/Nullable.php
@@ -36,7 +36,7 @@ final class Nullable implements Type
     /**
      * Provide access to the actual type directly, if needed.
      */
-    public function getActualType() : Type
+    public function getActualType(): Type
     {
         return $this->realType;
     }
@@ -44,7 +44,7 @@ final class Nullable implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return '?' . $this->realType->__toString();
     }

--- a/src/Types/Object_.php
+++ b/src/Types/Object_.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Reflection\Types;
 use InvalidArgumentException;
 use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Type;
+
 use function strpos;
 
 /**

--- a/src/Types/Object_.php
+++ b/src/Types/Object_.php
@@ -52,12 +52,12 @@ final class Object_ implements Type
     /**
      * Returns the FQSEN associated with this object.
      */
-    public function getFqsen() : ?Fqsen
+    public function getFqsen(): ?Fqsen
     {
         return $this->fqsen;
     }
 
-    public function __toString() : string
+    public function __toString(): string
     {
         if ($this->fqsen) {
             return (string) $this->fqsen;

--- a/src/Types/Parent_.php
+++ b/src/Types/Parent_.php
@@ -27,7 +27,7 @@ final class Parent_ implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'parent';
     }

--- a/src/Types/Resource_.php
+++ b/src/Types/Resource_.php
@@ -25,7 +25,7 @@ final class Resource_ implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'resource';
     }

--- a/src/Types/Scalar.php
+++ b/src/Types/Scalar.php
@@ -25,7 +25,7 @@ final class Scalar implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'scalar';
     }

--- a/src/Types/Self_.php
+++ b/src/Types/Self_.php
@@ -27,7 +27,7 @@ final class Self_ implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'self';
     }

--- a/src/Types/Static_.php
+++ b/src/Types/Static_.php
@@ -32,7 +32,7 @@ final class Static_ implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'static';
     }

--- a/src/Types/String_.php
+++ b/src/Types/String_.php
@@ -25,7 +25,7 @@ class String_ implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'string';
     }

--- a/src/Types/This.php
+++ b/src/Types/This.php
@@ -28,7 +28,7 @@ final class This implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return '$this';
     }

--- a/src/Types/Void_.php
+++ b/src/Types/Void_.php
@@ -28,7 +28,7 @@ final class Void_ implements Type
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
-    public function __toString() : string
+    public function __toString(): string
     {
         return 'void';
     }

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -33,7 +33,7 @@ class CollectionResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::__construct
      */
-    public function testResolvingCollection() : void
+    public function testResolvingCollection(): void
     {
         $fixture = new TypeResolver();
 
@@ -61,7 +61,7 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testResolvingCollectionWithKeyType() : void
+    public function testResolvingCollectionWithKeyType(): void
     {
         $fixture = new TypeResolver();
 
@@ -91,7 +91,7 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testResolvingArrayCollection() : void
+    public function testResolvingArrayCollection(): void
     {
         $fixture = new TypeResolver();
 
@@ -117,7 +117,7 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testResolvingArrayCollectionWithKey() : void
+    public function testResolvingArrayCollectionWithKey(): void
     {
         $fixture = new TypeResolver();
 
@@ -143,7 +143,7 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testResolvingArrayCollectionWithKeyAndWhitespace() : void
+    public function testResolvingArrayCollectionWithKeyAndWhitespace(): void
     {
         $fixture = new TypeResolver();
 
@@ -169,7 +169,7 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testResolvingArrayCollectionWithKeyAndTooManyWhitespace() : void
+    public function testResolvingArrayCollectionWithKeyAndTooManyWhitespace(): void
     {
         $this->expectException('InvalidArgumentException');
         $fixture = new TypeResolver();
@@ -186,7 +186,7 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testResolvingCollectionOfCollection() : void
+    public function testResolvingCollectionOfCollection(): void
     {
         $fixture = new TypeResolver();
 
@@ -215,7 +215,7 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testBadArrayCollectionKey() : void
+    public function testBadArrayCollectionKey(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('An array can have only integers or strings as keys');
@@ -227,7 +227,7 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testMissingStartCollection() : void
+    public function testMissingStartCollection(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Unexpected collection operator "<", class name is missing');
@@ -239,7 +239,7 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testMissingEndCollection() : void
+    public function testMissingEndCollection(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('Collection: ">" is missing');
@@ -251,7 +251,7 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testBadCollectionClass() : void
+    public function testBadCollectionClass(): void
     {
         $this->expectException('RuntimeException');
         $this->expectExceptionMessage('string is not a collection');
@@ -268,7 +268,7 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testResolvingCollectionAsArray() : void
+    public function testResolvingCollectionAsArray(): void
     {
         $fixture = new TypeResolver();
 

--- a/tests/unit/FqsenResolverTest.php
+++ b/tests/unit/FqsenResolverTest.php
@@ -25,7 +25,7 @@ final class FqsenResolverTest extends TestCase
     /**
      * @covers ::resolve
      */
-    public function testResolveFqsen() : void
+    public function testResolveFqsen(): void
     {
         $fqsenResolver = new FqsenResolver();
 
@@ -38,7 +38,7 @@ final class FqsenResolverTest extends TestCase
     /**
      * @covers ::resolve
      */
-    public function testResolveFqsenWithEmoji() : void
+    public function testResolveFqsenWithEmoji(): void
     {
         $fqsenResolver = new FqsenResolver();
 
@@ -51,7 +51,7 @@ final class FqsenResolverTest extends TestCase
     /**
      * @covers ::resolve
      */
-    public function testResolveWithoutContext() : void
+    public function testResolveWithoutContext(): void
     {
         $fqsenResolver = new FqsenResolver();
 
@@ -62,7 +62,7 @@ final class FqsenResolverTest extends TestCase
     /**
      * @covers ::resolve
      */
-    public function testResolveFromAlias() : void
+    public function testResolveFromAlias(): void
     {
         $fqsenResolver = new FqsenResolver();
 
@@ -75,7 +75,7 @@ final class FqsenResolverTest extends TestCase
     /**
      * @covers ::resolve
      */
-    public function testResolveFromPartialAlias() : void
+    public function testResolveFromPartialAlias(): void
     {
         $fqsenResolver = new FqsenResolver();
 
@@ -85,7 +85,7 @@ final class FqsenResolverTest extends TestCase
         static::assertSame('\some\other\ns', (string) $result);
     }
 
-    public function testResolveThrowsExceptionWhenGarbageInputIsPassed() : void
+    public function testResolveThrowsExceptionWhenGarbageInputIsPassed(): void
     {
         $this->expectException('InvalidArgumentException');
         $fqsenResolver = new FqsenResolver();

--- a/tests/unit/PseudoTypes/FalseTest.php
+++ b/tests/unit/PseudoTypes/FalseTest.php
@@ -24,7 +24,7 @@ final class FalseTest extends TestCase
     /**
      * @covers ::underlyingType
      */
-    public function testExposesUnderlyingType() : void
+    public function testExposesUnderlyingType(): void
     {
         $false = new False_();
 
@@ -34,7 +34,7 @@ final class FalseTest extends TestCase
     /**
      * @covers ::__toString
      */
-    public function testFalseStringifyCorrectly() : void
+    public function testFalseStringifyCorrectly(): void
     {
         $false = new False_();
 
@@ -44,7 +44,7 @@ final class FalseTest extends TestCase
     /**
      * @covers \phpDocumentor\Reflection\PseudoTypes\False_
      */
-    public function testCanBeInstantiatedUsingDeprecatedFqsen() : void
+    public function testCanBeInstantiatedUsingDeprecatedFqsen(): void
     {
         $false = new \phpDocumentor\Reflection\Types\False_();
 

--- a/tests/unit/PseudoTypes/TrueTest.php
+++ b/tests/unit/PseudoTypes/TrueTest.php
@@ -24,7 +24,7 @@ class TrueTest extends TestCase
     /**
      * @covers ::underlyingType
      */
-    public function testExposesUnderlyingType() : void
+    public function testExposesUnderlyingType(): void
     {
         $true = new True_();
 
@@ -34,7 +34,7 @@ class TrueTest extends TestCase
     /**
      * @covers ::__toString
      */
-    public function testTrueStringifyCorrectly() : void
+    public function testTrueStringifyCorrectly(): void
     {
         $true = new True_();
 
@@ -44,7 +44,7 @@ class TrueTest extends TestCase
     /**
      * @covers \phpDocumentor\Reflection\PseudoTypes\True_
      */
-    public function testCanBeInstantiatedUsingDeprecatedFqsen() : void
+    public function testCanBeInstantiatedUsingDeprecatedFqsen(): void
     {
         $true = new \phpDocumentor\Reflection\Types\True_();
 

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -29,6 +29,7 @@ use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 use stdClass;
+
 use function get_class;
 
 /**

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -47,7 +47,7 @@ class TypeResolverTest extends TestCase
      *
      * @dataProvider provideKeywords
      */
-    public function testResolvingKeywords(string $keyword, string $expectedClass) : void
+    public function testResolvingKeywords(string $keyword, string $expectedClass): void
     {
         $fixture = new TypeResolver();
 
@@ -67,7 +67,7 @@ class TypeResolverTest extends TestCase
      *
      * @dataProvider provideClassStrings
      */
-    public function testResolvingClassStrings(string $classString, bool $throwsException) : void
+    public function testResolvingClassStrings(string $classString, bool $throwsException): void
     {
         $fixture = new TypeResolver();
 
@@ -91,7 +91,7 @@ class TypeResolverTest extends TestCase
      *
      * @dataProvider provideInterfaceStrings
      */
-    public function testResolvingInterfaceStrings(string $interfaceString, bool $throwsException) : void
+    public function testResolvingInterfaceStrings(string $interfaceString, bool $throwsException): void
     {
         $fixture = new TypeResolver();
 
@@ -116,7 +116,7 @@ class TypeResolverTest extends TestCase
      *
      * @dataProvider provideFqcn
      */
-    public function testResolvingFQSENs(string $fqsen) : void
+    public function testResolvingFQSENs(string $fqsen): void
     {
         $fixture = new TypeResolver();
 
@@ -137,7 +137,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingRelativeQSENsBasedOnNamespace() : void
+    public function testResolvingRelativeQSENsBasedOnNamespace(): void
     {
         $fixture = new TypeResolver();
 
@@ -158,7 +158,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingRelativeQSENsBasedOnNamespaceAlias() : void
+    public function testResolvingRelativeQSENsBasedOnNamespaceAlias(): void
     {
         $fixture = new TypeResolver();
 
@@ -181,7 +181,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingTypedArrays() : void
+    public function testResolvingTypedArrays(): void
     {
         $fixture = new TypeResolver();
 
@@ -202,7 +202,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingNullableTypes() : void
+    public function testResolvingNullableTypes(): void
     {
         $fixture = new TypeResolver();
 
@@ -222,7 +222,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingNestedTypedArrays() : void
+    public function testResolvingNestedTypedArrays(): void
     {
         $fixture = new TypeResolver();
 
@@ -253,7 +253,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingCompoundTypes() : void
+    public function testResolvingCompoundTypes(): void
     {
         $fixture = new TypeResolver();
 
@@ -283,7 +283,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingAmpersandCompoundTypes() : void
+    public function testResolvingAmpersandCompoundTypes(): void
     {
         $fixture = new TypeResolver();
 
@@ -320,7 +320,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingMixedCompoundTypes() : void
+    public function testResolvingMixedCompoundTypes(): void
     {
         $fixture = new TypeResolver();
 
@@ -369,7 +369,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingCompoundTypedArrayTypes() : void
+    public function testResolvingCompoundTypedArrayTypes(): void
     {
         $fixture = new TypeResolver();
 
@@ -402,7 +402,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingNullableCompoundTypes() : void
+    public function testResolvingNullableCompoundTypes(): void
     {
         $fixture = new TypeResolver();
 
@@ -423,7 +423,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingArrayExpressionObjectsTypes() : void
+    public function testResolvingArrayExpressionObjectsTypes(): void
     {
         $fixture = new TypeResolver();
 
@@ -456,7 +456,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingArrayExpressionSimpleTypes() : void
+    public function testResolvingArrayExpressionSimpleTypes(): void
     {
         $fixture = new TypeResolver();
 
@@ -492,7 +492,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingArrayOfArrayExpressionTypes() : void
+    public function testResolvingArrayOfArrayExpressionTypes(): void
     {
         $fixture = new TypeResolver();
 
@@ -527,7 +527,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testReturnEmptyCompoundOnAnUnclosedArrayExpressionType() : void
+    public function testReturnEmptyCompoundOnAnUnclosedArrayExpressionType(): void
     {
         $fixture = new TypeResolver();
 
@@ -549,7 +549,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingArrayExpressionOrCompoundTypes() : void
+    public function testResolvingArrayExpressionOrCompoundTypes(): void
     {
         $fixture = new TypeResolver();
 
@@ -590,7 +590,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingIterableExpressionSimpleTypes() : void
+    public function testResolvingIterableExpressionSimpleTypes(): void
     {
         $fixture = new TypeResolver();
 
@@ -632,7 +632,7 @@ class TypeResolverTest extends TestCase
      * @covers ::resolve
      * @covers ::<private>
      */
-    public function testResolvingCompoundTypesWithTwoArrays() : void
+    public function testResolvingCompoundTypesWithTwoArrays(): void
     {
         $fixture = new TypeResolver();
 
@@ -659,7 +659,7 @@ class TypeResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::addKeyword
      */
-    public function testAddingAKeyword() : void
+    public function testAddingAKeyword(): void
     {
         // Assign
         $typeMock = self::createStub(Type::class);
@@ -680,7 +680,7 @@ class TypeResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::addKeyword
      */
-    public function testAddingAKeywordFailsIfTypeClassDoesNotExist() : void
+    public function testAddingAKeywordFailsIfTypeClassDoesNotExist(): void
     {
         $this->expectException('InvalidArgumentException');
         $fixture = new TypeResolver();
@@ -693,7 +693,7 @@ class TypeResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::addKeyword
      */
-    public function testAddingAKeywordFailsIfTypeClassDoesNotImplementTypeInterface() : void
+    public function testAddingAKeywordFailsIfTypeClassDoesNotImplementTypeInterface(): void
     {
         $this->expectException('InvalidArgumentException');
         $fixture = new TypeResolver();
@@ -706,7 +706,7 @@ class TypeResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testExceptionIsThrownIfTypeIsEmpty() : void
+    public function testExceptionIsThrownIfTypeIsEmpty(): void
     {
         $this->expectException('InvalidArgumentException');
         $fixture = new TypeResolver();
@@ -718,7 +718,7 @@ class TypeResolverTest extends TestCase
      *
      * @return string[][]
      */
-    public function provideKeywords() : array
+    public function provideKeywords(): array
     {
         return [
             ['string', Types\String_::class],
@@ -764,7 +764,7 @@ class TypeResolverTest extends TestCase
      *
      * @return (string|bool)[][]
      */
-    public function provideClassStrings() : array
+    public function provideClassStrings(): array
     {
         return [
             ['class-string<\phpDocumentor\Reflection>', false],
@@ -778,7 +778,7 @@ class TypeResolverTest extends TestCase
      *
      * @return (string|bool)[][]
      */
-    public function provideInterfaceStrings() : array
+    public function provideInterfaceStrings(): array
     {
         return [
             ['interface-string<\phpDocumentor\Reflection>', false],
@@ -792,7 +792,7 @@ class TypeResolverTest extends TestCase
      *
      * @return string[][]
      */
-    public function provideFqcn() : array
+    public function provideFqcn(): array
     {
         return [
             'namespace' => ['\phpDocumentor\Reflection'],
@@ -807,7 +807,7 @@ class TypeResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testArrayKeyValueSpecification() : void
+    public function testArrayKeyValueSpecification(): void
     {
         $fixture = new TypeResolver();
         $type = $fixture->resolve('array<string,array<int,string>>', new Context(''));

--- a/tests/unit/Types/ArrayKeyTest.php
+++ b/tests/unit/Types/ArrayKeyTest.php
@@ -24,7 +24,7 @@ final class ArrayKeyTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testArrayKeyCanBeConstructedAndStringifiedCorrectly() : void
+    public function testArrayKeyCanBeConstructedAndStringifiedCorrectly(): void
     {
         $this->assertSame('array-key', (string) (new ArrayKey()));
     }
@@ -34,7 +34,7 @@ final class ArrayKeyTest extends TestCase
      *
      * @covers ::getIterator
      */
-    public function testArrayKeyCanBeIterated() : void
+    public function testArrayKeyCanBeIterated(): void
     {
         $types = [String_::class, Integer::class];
 

--- a/tests/unit/Types/ArrayTest.php
+++ b/tests/unit/Types/ArrayTest.php
@@ -24,7 +24,7 @@ class ArrayTest extends TestCase
      * @dataProvider provideArrays
      * @covers ::__toString
      */
-    public function testArrayStringifyCorrectly(Array_ $array, string $expectedString) : void
+    public function testArrayStringifyCorrectly(Array_ $array, string $expectedString): void
     {
         $this->assertSame($expectedString, (string) $array);
     }
@@ -32,7 +32,7 @@ class ArrayTest extends TestCase
     /**
      * @return mixed[]
      */
-    public function provideArrays() : array
+    public function provideArrays(): array
     {
         return [
             'simple array' => [new Array_(), 'array'],

--- a/tests/unit/Types/BooleanTest.php
+++ b/tests/unit/Types/BooleanTest.php
@@ -23,7 +23,7 @@ final class BooleanTest extends TestCase
     /**
      * @covers ::__toString
      */
-    public function testBooleanStringifyCorrectly() : void
+    public function testBooleanStringifyCorrectly(): void
     {
         $type = new Boolean();
 

--- a/tests/unit/Types/ClassStringTest.php
+++ b/tests/unit/Types/ClassStringTest.php
@@ -25,7 +25,7 @@ class ClassStringTest extends TestCase
      * @dataProvider provideClassStrings
      * @covers ::__toString
      */
-    public function testClassStringStringifyCorrectly(ClassString $array, string $expectedString) : void
+    public function testClassStringStringifyCorrectly(ClassString $array, string $expectedString): void
     {
         $this->assertSame($expectedString, (string) $array);
     }
@@ -33,7 +33,7 @@ class ClassStringTest extends TestCase
     /**
      * @return mixed[]
      */
-    public function provideClassStrings() : array
+    public function provideClassStrings(): array
     {
         return [
             'generic class string' => [new ClassString(), 'class-string'],

--- a/tests/unit/Types/CollectionTest.php
+++ b/tests/unit/Types/CollectionTest.php
@@ -25,7 +25,7 @@ class CollectionTest extends TestCase
      * @dataProvider provideCollections
      * @covers ::__toString
      */
-    public function testCollectionStringifyCorrectly(Collection $collection, string $expectedString) : void
+    public function testCollectionStringifyCorrectly(Collection $collection, string $expectedString): void
     {
         $this->assertSame($expectedString, (string) $collection);
     }
@@ -33,7 +33,7 @@ class CollectionTest extends TestCase
     /**
      * @return mixed[]
      */
-    public function provideCollections() : array
+    public function provideCollections(): array
     {
         return [
             'simple collection' => [

--- a/tests/unit/Types/CompoundTest.php
+++ b/tests/unit/Types/CompoundTest.php
@@ -15,6 +15,7 @@ namespace phpDocumentor\Reflection\Types;
 
 use PHPUnit\Framework\TestCase;
 use TypeError;
+
 use function iterator_to_array;
 
 /**

--- a/tests/unit/Types/CompoundTest.php
+++ b/tests/unit/Types/CompoundTest.php
@@ -25,7 +25,7 @@ final class CompoundTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testCompoundCannotBeConstructedFromType() : void
+    public function testCompoundCannotBeConstructedFromType(): void
     {
         $this->expectException(TypeError::class);
         new Compound(['foo']);
@@ -38,7 +38,7 @@ final class CompoundTest extends TestCase
      *
      * @covers ::get
      */
-    public function testCompoundGetType() : void
+    public function testCompoundGetType(): void
     {
         $integer = new Integer();
 
@@ -51,7 +51,7 @@ final class CompoundTest extends TestCase
      *
      * @covers ::get
      */
-    public function testCompoundGetNotExistingType() : void
+    public function testCompoundGetNotExistingType(): void
     {
         $this->assertNull((new Compound([]))->get(0));
     }
@@ -62,7 +62,7 @@ final class CompoundTest extends TestCase
      *
      * @covers ::has
      */
-    public function testCompoundHasIndex() : void
+    public function testCompoundHasIndex(): void
     {
         $this->assertTrue((new Compound([new Integer()]))->has(0));
     }
@@ -72,7 +72,7 @@ final class CompoundTest extends TestCase
      *
      * @covers ::has
      */
-    public function testCompoundDoesNotHasIndex() : void
+    public function testCompoundDoesNotHasIndex(): void
     {
         $this->assertFalse((new Compound([]))->has(0));
     }
@@ -83,7 +83,7 @@ final class CompoundTest extends TestCase
      *
      * @covers ::contains
      */
-    public function testCompoundContainsType() : void
+    public function testCompoundContainsType(): void
     {
         $this->assertTrue((new Compound([new Integer()]))->contains(new Integer()));
     }
@@ -95,7 +95,7 @@ final class CompoundTest extends TestCase
      *
      * @covers ::contains
      */
-    public function testCompoundDoesNotContainType() : void
+    public function testCompoundDoesNotContainType(): void
     {
         $this->assertFalse((new Compound([new Integer()]))->contains(new String_()));
     }
@@ -107,7 +107,7 @@ final class CompoundTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testCompoundCanBeConstructedAndStringifiedCorrectly() : void
+    public function testCompoundCanBeConstructedAndStringifiedCorrectly(): void
     {
         $this->assertSame('int|bool', (string) (new Compound([new Integer(), new Boolean()])));
     }
@@ -119,7 +119,7 @@ final class CompoundTest extends TestCase
      * @covers ::__construct
      * @covers ::__toString
      */
-    public function testCompoundDoesNotContainDuplicates() : void
+    public function testCompoundDoesNotContainDuplicates(): void
     {
         $compound = new Compound([new Integer(), new Integer(), new Boolean()]);
 
@@ -134,7 +134,7 @@ final class CompoundTest extends TestCase
      *
      * @covers ::getIterator
      */
-    public function testCompoundCanBeIterated() : void
+    public function testCompoundCanBeIterated(): void
     {
         $types = [new Integer(), new Boolean()];
 

--- a/tests/unit/Types/ContextTest.php
+++ b/tests/unit/Types/ContextTest.php
@@ -24,7 +24,7 @@ class ContextTest extends TestCase
      * @covers ::__construct
      * @covers ::getNamespace
      */
-    public function testProvidesANormalizedNamespace() : void
+    public function testProvidesANormalizedNamespace(): void
     {
         $fixture = new Context('\My\Space');
         $this->assertSame('My\Space', $fixture->getNamespace());
@@ -34,7 +34,7 @@ class ContextTest extends TestCase
      * @covers ::__construct
      * @covers ::getNamespace
      */
-    public function testInterpretsNamespaceNamedGlobalAsRootNamespace() : void
+    public function testInterpretsNamespaceNamedGlobalAsRootNamespace(): void
     {
         $fixture = new Context('global');
         $this->assertSame('', $fixture->getNamespace());
@@ -44,7 +44,7 @@ class ContextTest extends TestCase
      * @covers ::__construct
      * @covers ::getNamespace
      */
-    public function testInterpretsNamespaceNamedDefaultAsRootNamespace() : void
+    public function testInterpretsNamespaceNamedDefaultAsRootNamespace(): void
     {
         $fixture = new Context('default');
         $this->assertSame('', $fixture->getNamespace());
@@ -54,7 +54,7 @@ class ContextTest extends TestCase
      * @covers ::__construct
      * @covers ::getNamespaceAliases
      */
-    public function testProvidesNormalizedNamespaceAliases() : void
+    public function testProvidesNormalizedNamespaceAliases(): void
     {
         $fixture = new Context('', ['Space' => '\My\Space']);
         $this->assertSame(['Space' => 'My\Space'], $fixture->getNamespaceAliases());

--- a/tests/unit/Types/InterfaceStringTest.php
+++ b/tests/unit/Types/InterfaceStringTest.php
@@ -25,7 +25,7 @@ class InterfaceStringTest extends TestCase
      * @dataProvider provideInterfaceStrings
      * @covers ::__toString
      */
-    public function testInterfaceStringStringifyCorrectly(InterfaceString $array, string $expectedString) : void
+    public function testInterfaceStringStringifyCorrectly(InterfaceString $array, string $expectedString): void
     {
         $this->assertSame($expectedString, (string) $array);
     }
@@ -33,7 +33,7 @@ class InterfaceStringTest extends TestCase
     /**
      * @return mixed[]
      */
-    public function provideInterfaceStrings() : array
+    public function provideInterfaceStrings(): array
     {
         return [
             'generic interface string' => [new InterfaceString(), 'interface-string'],

--- a/tests/unit/Types/IterableTest.php
+++ b/tests/unit/Types/IterableTest.php
@@ -24,7 +24,7 @@ class IterableTest extends TestCase
      * @covers ::__toString
      * @dataProvider provideIterables
      */
-    public function testIterableStringifyCorrectly(Iterable_ $iterable, string $expectedString) : void
+    public function testIterableStringifyCorrectly(Iterable_ $iterable, string $expectedString): void
     {
         $this->assertSame($expectedString, (string) $iterable);
     }
@@ -32,7 +32,7 @@ class IterableTest extends TestCase
     /**
      * @return mixed[]
      */
-    public function provideIterables() : array
+    public function provideIterables(): array
     {
         return [
             'simple iterable' => [new Iterable_(), 'iterable'],

--- a/tests/unit/Types/NullableTest.php
+++ b/tests/unit/Types/NullableTest.php
@@ -24,7 +24,7 @@ class NullableTest extends TestCase
      * @covers ::__construct
      * @covers ::getActualType
      */
-    public function testNullableTypeWrapsCorrectly() : void
+    public function testNullableTypeWrapsCorrectly(): void
     {
         $realType = new String_();
 
@@ -36,7 +36,7 @@ class NullableTest extends TestCase
     /**
      * @covers ::__toString
      */
-    public function testNullableStringifyCorrectly() : void
+    public function testNullableStringifyCorrectly(): void
     {
         $this->assertSame('?string', (string) new Nullable(new String_()));
     }


### PR DESCRIPTION
### PHPCS ruleset: update ruleset for upstream changes

* Fix the name and description to prevent confusion between the project ruleset and the organisation ruleset.
* Set the minimum PHP version for the PHPCompatibility standard.
* Ignore two PHPCompatibility non-issues.
* Don't require property type declarations.
* Ensure special characters used as literals in an exclude pattern are escaped.

### CS: no whitespace before return type colon

### CS: blank line between different use statement types

### CS: import all things

### CS: miscellaneous other whitespace fixes 