### PR TITLE
GH Actions: don't allow builds against PHP 8.1 to fail

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -58,7 +58,6 @@ jobs:
   phpunit:
     name: Unit tests for PHP version ${{ matrix.php-versions }} on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
-    continue-on-error: ${{ matrix.php-versions == '8.1' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
The tests currently pass, let's keep it that way ;-)