### PR TITLE
Add support for never keyword

### DIFF
--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -107,6 +107,7 @@ final class TypeResolver
         'static' => Types\Static_::class,
         'parent' => Types\Parent_::class,
         'iterable' => Types\Iterable_::class,
+        'never' => Types\Never_::class,
     ];
 
     /**

--- a/src/Types/Never_.php
+++ b/src/Types/Never_.php
@@ -16,7 +16,7 @@ namespace phpDocumentor\Reflection\Types;
 use phpDocumentor\Reflection\Type;
 
 /**
- * Value Object representing the pseudo-type 'never'.
+ * Value Object representing the return-type 'never'.
  *
  * Never is generally only used when working with return types as it signifies that the method that only
  * ever throw or exit.

--- a/src/Types/Never_.php
+++ b/src/Types/Never_.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\Types;
+
+use phpDocumentor\Reflection\Type;
+
+/**
+ * Value Object representing the pseudo-type 'never'.
+ *
+ * Never is generally only used when working with return types as it signifies that the method that only
+ * ever throw or exit.
+ *
+ * @psalm-immutable
+ */
+final class Never_ implements Type
+{
+    /**
+     * Returns a rendered output of the Type as it would be used in a DocBlock.
+     */
+    public function __toString(): string
+    {
+        return 'never';
+    }
+}

--- a/src/Types/Void_.php
+++ b/src/Types/Void_.php
@@ -16,7 +16,7 @@ namespace phpDocumentor\Reflection\Types;
 use phpDocumentor\Reflection\Type;
 
 /**
- * Value Object representing the pseudo-type 'void'.
+ * Value Object representing the return-type 'void'.
  *
  * Void is generally only used when working with return types as it signifies that the method intentionally does not
  * return any value.

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -757,6 +757,7 @@ class TypeResolverTest extends TestCase
             ['self', Types\Self_::class],
             ['parent', Types\Parent_::class],
             ['iterable', Types\Iterable_::class],
+            ['never', Types\Never_::class],
         ];
     }
 


### PR DESCRIPTION
php 8.1 introduces the `never` keyword, which can be used as return type.