### PR TITLE
Fix: An array can have only integers or strings as keys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ psalm:
 
 .PHONY: test
 test:
-	docker run -it --rm -v${PWD}:/opt/project -w /opt/project php:7.2 tools/phpunit
+	docker run -it --rm -v${PWD}:/opt/project -w /opt/project php:7.3 tools/phpunit
 
 .PHONY: pre-commit-test
 pre-commit-test: test phpcs phpstan psalm

--- a/src/PseudoTypes/LiteralString.php
+++ b/src/PseudoTypes/LiteralString.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\PseudoType;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\String_;
+
+/**
+ * Value Object representing the type 'string'.
+ *
+ * @psalm-immutable
+ */
+final class LiteralString extends String_ implements PseudoType
+{
+    public function underlyingType(): Type
+    {
+        return new String_();
+    }
+
+    /**
+     * Returns a rendered output of the Type as it would be used in a DocBlock.
+     */
+    public function __toString(): string
+    {
+        return 'literal-string';
+    }
+}

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -102,6 +102,7 @@ final class TypeResolver
         'callable-string' => PseudoTypes\CallableString::class,
         'false' => PseudoTypes\False_::class,
         'true' => PseudoTypes\True_::class,
+        'literal-string' => PseudoTypes\LiteralString::class,
         'self' => Types\Self_::class,
         '$this' => Types\This::class,
         'static' => Types\Static_::class,

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -16,6 +16,7 @@ namespace phpDocumentor\Reflection;
 use ArrayIterator;
 use InvalidArgumentException;
 use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\ArrayKey;
 use phpDocumentor\Reflection\Types\ClassString;
 use phpDocumentor\Reflection\Types\Collection;
 use phpDocumentor\Reflection\Types\Compound;
@@ -544,6 +545,7 @@ final class TypeResolver
                 // check the key type for an "array" collection. We allow only
                 // strings or integers.
                 if (
+                    !$keyType instanceof ArrayKey &&
                     !$keyType instanceof String_ &&
                     !$keyType instanceof Integer &&
                     !$keyType instanceof Compound
@@ -556,6 +558,7 @@ final class TypeResolver
                 if ($keyType instanceof Compound) {
                     foreach ($keyType->getIterator() as $item) {
                         if (
+                            !$item instanceof ArrayKey &&
                             !$item instanceof String_ &&
                             !$item instanceof Integer
                         ) {

--- a/src/Types/ArrayKey.php
+++ b/src/Types/ArrayKey.php
@@ -13,6 +13,9 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Reflection\Types;
 
+use phpDocumentor\Reflection\PseudoType;
+use phpDocumentor\Reflection\Type;
+
 /**
  * Value Object representing a array-key Type.
  *
@@ -20,11 +23,16 @@ namespace phpDocumentor\Reflection\Types;
  *
  * @psalm-immutable
  */
-final class ArrayKey extends AggregatedType
+final class ArrayKey extends AggregatedType implements PseudoType
 {
     public function __construct()
     {
         parent::__construct([new String_(), new Integer()], '|');
+    }
+
+    public function underlyingType(): Type
+    {
+        return new String_();
     }
 
     public function __toString(): string

--- a/src/Types/ArrayKey.php
+++ b/src/Types/ArrayKey.php
@@ -32,7 +32,7 @@ final class ArrayKey extends AggregatedType implements PseudoType
 
     public function underlyingType(): Type
     {
-        return new String_();
+        return new Compound([new String_(), new Integer()]);
     }
 
     public function __toString(): string

--- a/src/Types/ClassString.php
+++ b/src/Types/ClassString.php
@@ -14,13 +14,15 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\Types;
 
 use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\PseudoType;
+use phpDocumentor\Reflection\Type;
 
 /**
  * Value Object representing the type 'string'.
  *
  * @psalm-immutable
  */
-final class ClassString extends String_
+final class ClassString extends String_ implements PseudoType
 {
     /** @var Fqsen|null */
     private $fqsen;
@@ -31,6 +33,11 @@ final class ClassString extends String_
     public function __construct(?Fqsen $fqsen = null)
     {
         $this->fqsen = $fqsen;
+    }
+
+    public function underlyingType(): Type
+    {
+        return new String_();
     }
 
     /**

--- a/src/Types/ClassString.php
+++ b/src/Types/ClassString.php
@@ -14,14 +14,13 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\Types;
 
 use phpDocumentor\Reflection\Fqsen;
-use phpDocumentor\Reflection\Type;
 
 /**
  * Value Object representing the type 'string'.
  *
  * @psalm-immutable
  */
-final class ClassString implements Type
+final class ClassString extends String_
 {
     /** @var Fqsen|null */
     private $fqsen;

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -227,6 +227,19 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
+    public function testGoodArrayCollectionKey(): void
+    {
+        $fixture = new TypeResolver();
+        $fixture->resolve('array<array-key,string>', new Context(''));
+
+        $fixture = new TypeResolver();
+        $fixture->resolve('array<class-string,string>', new Context(''));
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::resolve
+     */
     public function testMissingStartCollection(): void
     {
         $this->expectException('RuntimeException');

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -758,6 +758,7 @@ class TypeResolverTest extends TestCase
             ['parent', Types\Parent_::class],
             ['iterable', Types\Iterable_::class],
             ['never', Types\Never_::class],
+            ['literal-string', PseudoTypes\LiteralString::class],
         ];
     }
 


### PR DESCRIPTION
We should allow all kind of string types here. We currently do not have an array-key interface or something like that, so I added the new type into the check.