### PR TITLE
Throw exception on invalid array start

### DIFF
--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -38,6 +38,7 @@ use function array_values;
 use function class_exists;
 use function class_implements;
 use function count;
+use function current;
 use function end;
 use function in_array;
 use function key;
@@ -273,6 +274,10 @@ final class TypeResolver
             } elseif ($token === self::OPERATOR_ARRAY) {
                 end($types);
                 $last = key($types);
+                if ($last === null) {
+                    throw new InvalidArgumentException('Unexpected array operator');
+                }
+
                 $lastItem = $types[$last];
                 if ($lastItem instanceof Expression) {
                     $lastItem = $lastItem->getValueType();
@@ -317,7 +322,7 @@ final class TypeResolver
                 );
             }
         } elseif (count($types) === 1) {
-            return $types[0];
+            return current($types);
         }
 
         if ($compoundToken === '|') {

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -715,6 +715,19 @@ class TypeResolverTest extends TestCase
     }
 
     /**
+     * @uses \phpDocumentor\Reflection\Types\Context
+     *
+     * @covers ::__construct
+     * @covers ::resolve
+     */
+    public function testInvalidArrayOperator(): void
+    {
+        $this->expectException('InvalidArgumentException');
+        $fixture = new TypeResolver();
+        $fixture->resolve('[]', new Context(''));
+    }
+
+    /**
      * Returns a list of keywords and expected classes that are created from them.
      *
      * @return string[][]


### PR DESCRIPTION
When the current type index is null, no type was resolved yet. So
an array start is invalid. An `[]` array operator should always be
prefixed with a type notation.

refs #141 