### PR TITLE
fix for multiple class-string classes

### DIFF
--- a/src/Types/AbstractList.php
+++ b/src/Types/AbstractList.php
@@ -15,6 +15,9 @@ namespace phpDocumentor\Reflection\Types;
 
 use phpDocumentor\Reflection\Type;
 
+use function count;
+use function implode;
+
 /**
  * Represents a list of values. This is an abstract class for Array_ and Collection.
  *
@@ -67,6 +70,30 @@ abstract class AbstractList implements Type
     public function __toString(): string
     {
         if ($this->keyType) {
+            $classStringValues = [];
+            if ($this->valueType instanceof AggregatedType) {
+                /**
+                 * @psalm-suppress ImpureMethodCall
+                 */
+                foreach ($this->valueType->getIterator() as $typeInner) {
+                    if (!($typeInner instanceof ClassString)) {
+                        $classStringValues = [];
+                        break;
+                    }
+
+                    $fqsenTmp = $typeInner->getFqsen();
+                    if (!$fqsenTmp) {
+                        continue;
+                    }
+
+                    $classStringValues[] = $fqsenTmp->__toString();
+                }
+            }
+
+            if (count($classStringValues) > 0) {
+                return 'array<' . $this->keyType . ',class-string<' . implode('|', $classStringValues) . '>>';
+            }
+
             return 'array<' . $this->keyType . ',' . $this->valueType . '>';
         }
 

--- a/src/Types/AggregatedType.php
+++ b/src/Types/AggregatedType.php
@@ -77,7 +77,6 @@ abstract class AggregatedType implements Type, IteratorAggregate
     public function contains(Type $type): bool
     {
         foreach ($this->types as $typePart) {
-            // if the type is duplicate; do not add it
             if ((string) $typePart === (string) $type) {
                 return true;
             }

--- a/tests/unit/ClassStringResolverTest.php
+++ b/tests/unit/ClassStringResolverTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection;
+
+use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\ClassString;
+use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Context;
+use phpDocumentor\Reflection\Types\Integer;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers ::<private>
+ * @coversDefaultClass \phpDocumentor\Reflection\TypeResolver
+ */
+class ClassStringResolverTest extends TestCase
+{
+    /**
+     * @uses \phpDocumentor\Reflection\Types\Array_
+     * @uses \phpDocumentor\Reflection\Types\Integer
+     * @uses \phpDocumentor\Reflection\Types\ClassString
+     *
+     * @covers ::__construct
+     * @covers ::resolve
+     */
+    public function testResolvingClassString(): void
+    {
+        $fixture = new TypeResolver();
+
+        $resolvedType = $fixture->resolve('array<int,class-string<\Foo\Bar>>', new Context(''));
+
+        $this->assertInstanceOf(Array_::class, $resolvedType);
+        $this->assertSame('array<int,class-string<\Foo\Bar>>', (string) $resolvedType);
+
+        $keyType = $resolvedType->getKeyType();
+        $valueTpye = $resolvedType->getValueType();
+
+        $this->assertInstanceOf(Integer::class, $keyType);
+
+        $this->assertInstanceOf(ClassString::class, $valueTpye);
+        $this->assertSame('Bar', $valueTpye->getFqsen()->getName());
+        $this->assertSame('\Foo\Bar', $valueTpye->getFqsen()->__toString());
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\Types\Array_
+     * @uses \phpDocumentor\Reflection\Types\Integer
+     * @uses \phpDocumentor\Reflection\Types\ClassString
+     *
+     * @covers ::__construct
+     * @covers ::resolve
+     */
+    public function testResolvingClassStrings(): void
+    {
+        $fixture = new TypeResolver();
+
+        $resolvedType = $fixture->resolve('array<int,class-string<\Foo\Bar|\Foo\Lall>>', new Context(''));
+
+        $this->assertInstanceOf(Array_::class, $resolvedType);
+        $this->assertSame('array<int,class-string<\Foo\Bar|\Foo\Lall>>', (string) $resolvedType);
+
+        $keyType = $resolvedType->getKeyType();
+        $valueTpye = $resolvedType->getValueType();
+
+        $this->assertInstanceOf(Integer::class, $keyType);
+
+        $this->assertInstanceOf(Compound::class, $valueTpye);
+        foreach ($valueTpye->getIterator() as $type) {
+            $this->assertInstanceOf(ClassString::class, $type);
+        }
+    }
+}


### PR DESCRIPTION
e.g.: `class-string<\Foo\Bar|\Foo\Lall>` 

⇒ currently this will throw an exception like `\Foo\Bar|\Foo\Lall is not a class string`