### PR TITLE
Fix parsing nullable collections

### DIFF
--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -210,6 +210,7 @@ final class TypeResolver
                         self::PARSER_IN_COMPOUND,
                         self::PARSER_IN_ARRAY_EXPRESSION,
                         self::PARSER_IN_COLLECTION_EXPRESSION,
+                        self::PARSER_IN_NULLABLE,
                     ], true)
                 ) {
                     throw new RuntimeException(
@@ -225,6 +226,7 @@ final class TypeResolver
                         self::PARSER_IN_COMPOUND,
                         self::PARSER_IN_ARRAY_EXPRESSION,
                         self::PARSER_IN_COLLECTION_EXPRESSION,
+                        self::PARSER_IN_NULLABLE,
                     ], true)
                 ) {
                     throw new RuntimeException(

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -293,13 +293,8 @@ final class TypeResolver
 
                 $tokens->next();
             } else {
-                $type = $this->resolveSingleType($token, $context);
+                $types[] = $this->resolveSingleType($token, $context);
                 $tokens->next();
-                if ($parserContext === self::PARSER_IN_NULLABLE) {
-                    return $type;
-                }
-
-                $types[] = $type;
             }
         }
 

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -328,4 +328,21 @@ class CollectionResolverTest extends TestCase
         $this->assertInstanceOf(Types\String_::class, $valueType);
         $this->assertInstanceOf(Types\Integer::class, $keyType);
     }
+
+    /**
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\Nullable
+     *
+     * @covers ::__construct
+     * @covers ::resolve
+     */
+    public function testResolvingNullableArray(): void
+    {
+        $fixture = new TypeResolver();
+
+        $resolvedType = $fixture->resolve('?array<int>', new Context(''));
+
+        $this->assertInstanceOf(Types\Nullable::class, $resolvedType);
+        $this->assertSame('?int[]', (string) $resolvedType);
+    }
 }

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -407,9 +407,9 @@ class TypeResolverTest extends TestCase
     {
         $fixture = new TypeResolver();
 
+        $this->expectException('RuntimeException');
+        $this->expectExceptionMessage('Unexpected type separator');
         $resolvedType = $fixture->resolve('?string|null|?boolean');
-
-        $this->assertSame('?string|null|?bool', (string) $resolvedType);
     }
 
     /**

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -407,9 +407,11 @@ class TypeResolverTest extends TestCase
     {
         $fixture = new TypeResolver();
 
-        $this->expectException('RuntimeException');
-        $this->expectExceptionMessage('Unexpected type separator');
+        // Note that in PHP types it is illegal to use shorthand nullable
+        // syntax with unions. This would be 'string|boolean|null' instead.
         $resolvedType = $fixture->resolve('?string|null|?boolean');
+
+        $this->assertSame('?string|null|?bool', (string) $resolvedType);
     }
 
     /**


### PR DESCRIPTION
Fixes #163.
Fixes phpDocumentor/phpDocumentor#3290.

Shorthand nullable type syntax is now supported for collection types
(e.g. `?array<int>`).

This also prevents a misuse of the shorthand nullable type syntax with
compound types, which is illegal with PHP types. This is documented in
the Union Types 2.0 RFC (https://wiki.php.net/rfc/union_types_v2) by
N. Popov:

> Union types and the ?T nullable type notation cannot be mixed.
> Writing ?T1|T2, T1|?T2 or ?(T1|T2) is not supported and T1|T2|null
> needs to be used instead.