### PR TITLE
Feature/advanced type support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ vendor: composer.json composer.lock
 
 .PHONY: benchmark
 benchmark:
-	docker run -it --rm -v${CURDIR}:/opt/project -w /opt/project php:7.4-cli tools/phpbench run
+	docker run -it --rm -v${CURDIR}:/opt/project -w /opt/project php:7.4-cli vendor/bin/phpbench run
 
 .PHONY: rector
 rector: ## Refactor code using rector

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
-        "phpdocumentor/reflection-common": "^2.0"
+        "phpdocumentor/reflection-common": "^2.0",
+        "phpstan/phpdoc-parser": "^1.13"
     },
     "require-dev": {
         "ext-tokenizer": "*",
@@ -20,7 +21,8 @@
         "phpstan/phpstan-phpunit": "^1.1",
         "phpstan/extension-installer": "^1.1",
         "vimeo/psalm": "^4.25",
-        "rector/rector": "^0.13.9"
+        "rector/rector": "^0.13.9",
+        "phpbench/phpbench": "^1.2"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0995b56862f68800c3c014da7cd2503f",
+    "content-hash": "e012cde7a3d864a1bed7eea7698cf2eb",
     "packages": [
         {
             "name": "phpdocumentor/reflection-common",
@@ -58,6 +58,51 @@
                 "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
             },
             "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.13.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "33aefcdab42900e36366d0feab6206e2dd68f947"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/33aefcdab42900e36366d0feab6206e2dd68f947",
+                "reference": "33aefcdab42900e36366d0feab6206e2dd68f947",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.5",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.13.0"
+            },
+            "time": "2022-10-21T09:57:39+00:00"
         }
     ],
     "packages-dev": [
@@ -556,6 +601,79 @@
             "time": "2019-12-04T15:06:13+00:00"
         },
         {
+            "name": "doctrine/annotations",
+            "version": "1.13.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/648b0343343565c4a056bfc8392201385e8d89f0",
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "ext-tokenizer": "*",
+                "php": "^7.1 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^1.11 || ^2.0",
+                "doctrine/coding-standard": "^6.0 || ^8.1",
+                "phpstan/phpstan": "^1.4.10 || ^1.8.0",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
+                "symfony/cache": "^4.4 || ^5.2",
+                "vimeo/psalm": "^4.10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/1.13.3"
+            },
+            "time": "2022-07-02T10:48:51+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.1",
             "source": {
@@ -624,6 +742,82 @@
                 }
             ],
             "time": "2022-03-03T08:28:38+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/c268e882d4dbdd85e36e4ad69e02dc284f89d229",
+                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9.0",
+                "phpstan/phpstan": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-28T11:07:21+00:00"
         },
         {
             "name": "felixfbecker/advanced-json-rpc",
@@ -1055,6 +1249,198 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpbench/container",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpbench/container.git",
+                "reference": "6d555ff7174fca13f9b1ec0b4a089ed41d0ab392"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpbench/container/zipball/6d555ff7174fca13f9b1ec0b4a089ed41d0ab392",
+                "reference": "6d555ff7174fca13f9b1ec0b4a089ed41d0ab392",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0|^2.0",
+                "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.16",
+                "phpstan/phpstan": "^0.12.52",
+                "phpunit/phpunit": "^8"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpBench\\DependencyInjection\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "Simple, configurable, service container.",
+            "support": {
+                "issues": "https://github.com/phpbench/container/issues",
+                "source": "https://github.com/phpbench/container/tree/2.2.1"
+            },
+            "time": "2022-01-25T10:17:35+00:00"
+        },
+        {
+            "name": "phpbench/dom",
+            "version": "0.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpbench/dom.git",
+                "reference": "b013b717832ddbaadf2a40984b04bc66af9a7110"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpbench/dom/zipball/b013b717832ddbaadf2a40984b04bc66af9a7110",
+                "reference": "b013b717832ddbaadf2a40984b04bc66af9a7110",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^7.2||^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.18",
+                "phpstan/phpstan": "^0.12.83",
+                "phpunit/phpunit": "^8.0||^9.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpBench\\Dom\\": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "DOM wrapper to simplify working with the PHP DOM implementation",
+            "support": {
+                "issues": "https://github.com/phpbench/dom/issues",
+                "source": "https://github.com/phpbench/dom/tree/0.3.2"
+            },
+            "time": "2021-09-24T15:26:07+00:00"
+        },
+        {
+            "name": "phpbench/phpbench",
+            "version": "1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpbench/phpbench.git",
+                "reference": "dce145304abbb16c8d9af69c19d96f47e9d0e670"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpbench/phpbench/zipball/dce145304abbb16c8d9af69c19d96f47e9d0e670",
+                "reference": "dce145304abbb16c8d9af69c19d96f47e9d0e670",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/annotations": "^1.13",
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-spl": "*",
+                "ext-tokenizer": "*",
+                "php": "^7.3 || ^8.0",
+                "phpbench/container": "^2.1",
+                "phpbench/dom": "~0.3.1",
+                "psr/log": "^1.1 || ^2.0 || ^3.0",
+                "seld/jsonlint": "^1.1",
+                "symfony/console": "^4.2 || ^5.0  || ^6.0",
+                "symfony/filesystem": "^4.2 || ^5.0 || ^6.0",
+                "symfony/finder": "^4.2 || ^5.0 || ^6.0",
+                "symfony/options-resolver": "^4.2 || ^5.0 || ^6.0",
+                "symfony/process": "^4.2 || ^5.0 || ^6.0",
+                "webmozart/glob": "^4.6"
+            },
+            "require-dev": {
+                "dantleech/invoke": "^2.0",
+                "friendsofphp/php-cs-fixer": "^3.0",
+                "jangregor/phpstan-prophecy": "^1.0",
+                "phpspec/prophecy": "^1.12",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^8.5.8 || ^9.0",
+                "symfony/error-handler": "^5.2 || ^6.0",
+                "symfony/var-dumper": "^4.0 || ^5.0 || ^6.0"
+            },
+            "suggest": {
+                "ext-xdebug": "For Xdebug profiling extension."
+            },
+            "bin": [
+                "bin/phpbench"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "lib/Report/Func/functions.php"
+                ],
+                "psr-4": {
+                    "PhpBench\\": "lib/",
+                    "PhpBench\\Extensions\\XDebug\\": "extensions/xdebug/lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniel Leech",
+                    "email": "daniel@dantleech.com"
+                }
+            ],
+            "description": "PHP Benchmarking Framework",
+            "support": {
+                "issues": "https://github.com/phpbench/phpbench/issues",
+                "source": "https://github.com/phpbench/phpbench/tree/1.2.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/dantleech",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-10-15T09:57:51+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -1755,6 +2141,55 @@
                 }
             ],
             "time": "2022-06-19T12:14:25+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "reference": "d11b50ad223250cf17b86e38383413f5a6764bf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/master"
+            },
+            "time": "2016-08-06T20:24:11+00:00"
         },
         {
             "name": "psr/container",
@@ -2879,6 +3314,70 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
+            "name": "seld/jsonlint",
+            "version": "1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Seldaek/jsonlint.git",
+                "reference": "4211420d25eba80712bff236a98960ef68b866b7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Seldaek/jsonlint/zipball/4211420d25eba80712bff236a98960ef68b866b7",
+                "reference": "4211420d25eba80712bff236a98960ef68b866b7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.5",
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0 || ^8.5.13"
+            },
+            "bin": [
+                "bin/jsonlint"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Seld\\JsonLint\\": "src/Seld/JsonLint/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                }
+            ],
+            "description": "JSON Linter",
+            "keywords": [
+                "json",
+                "linter",
+                "parser",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/Seldaek/jsonlint/issues",
+                "source": "https://github.com/Seldaek/jsonlint/tree/1.9.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Seldaek",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/seld/jsonlint",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-04-01T13:37:23+00:00"
+        },
+        {
             "name": "symfony/console",
             "version": "v5.4.11",
             "source": {
@@ -3043,6 +3542,202 @@
                 }
             ],
             "time": "2022-01-02T09:53:40+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v5.4.13",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "ac09569844a9109a5966b9438fc29113ce77cf51"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/ac09569844a9109a5966b9438fc29113ce77cf51",
+                "reference": "ac09569844a9109a5966b9438fc29113ce77cf51",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.13"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-09-21T19:53:16+00:00"
+        },
+        {
+            "name": "symfony/finder",
+            "version": "v5.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/finder.git",
+                "reference": "7872a66f57caffa2916a584db1aa7f12adc76f8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/7872a66f57caffa2916a584db1aa7f12adc76f8c",
+                "reference": "7872a66f57caffa2916a584db1aa7f12adc76f8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Finder\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Finds files and directories via an intuitive fluent interface",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/finder/tree/v5.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-07-29T07:37:50+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v5.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "54f14e36aa73cb8f7261d7686691fd4d75ea2690"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/54f14e36aa73cb8f7261d7686691fd4d75ea2690",
+                "reference": "54f14e36aa73cb8f7261d7686691fd4d75ea2690",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-php73": "~1.0",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v5.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-07-20T13:00:38+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3537,6 +4232,68 @@
             "time": "2022-05-10T07:21:04+00:00"
         },
         {
+            "name": "symfony/process",
+            "version": "v5.4.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/process.git",
+                "reference": "6e75fe6874cbc7e4773d049616ab450eff537bf1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/process/zipball/6e75fe6874cbc7e4773d049616ab450eff537bf1",
+                "reference": "6e75fe6874cbc7e4773d049616ab450eff537bf1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/polyfill-php80": "^1.16"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Executes commands in sub-processes",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/process/tree/v5.4.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-06-27T16:58:25+00:00"
+        },
+        {
             "name": "symfony/service-contracts",
             "version": "v2.5.2",
             "source": {
@@ -3919,6 +4676,55 @@
                 "source": "https://github.com/webmozarts/assert/tree/1.11.0"
             },
             "time": "2022-06-03T18:03:27+00:00"
+        },
+        {
+            "name": "webmozart/glob",
+            "version": "4.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/glob.git",
+                "reference": "3c17f7dec3d9d0e87b575026011f2e75a56ed655"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/glob/zipball/3c17f7dec3d9d0e87b575026011f2e75a56ed655",
+                "reference": "3c17f7dec3d9d0e87b575026011f2e75a56ed655",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5",
+                "symfony/filesystem": "^5.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Glob\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "A PHP implementation of Ant's glob.",
+            "support": {
+                "issues": "https://github.com/webmozarts/glob/issues",
+                "source": "https://github.com/webmozarts/glob/tree/4.6.0"
+            },
+            "time": "2022-05-24T19:45:58+00:00"
         },
         {
             "name": "webmozart/path-util",

--- a/phive.xml
+++ b/phive.xml
@@ -1,4 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<phive xmlns="https://phar.io/phive">
-  <phar name="phpunit" version="^9.5" installed="9.5.8" location="./tools/phpunit" copy="true"/>
-</phive>

--- a/phpbench.json
+++ b/phpbench.json
@@ -1,4 +1,6 @@
 {
-  "bootstrap": "vendor/autoload.php",
-  "path": "tests/benchmark"
+  "$schema":"./vendor/phpbench/phpbench/phpbench.schema.json",
+  "runner.bootstrap": "vendor/autoload.php",
+  "runner.path": "tests/benchmark",
+  "runner.file_pattern": "*Bench.php"
 }

--- a/src/PseudoTypes/ArrayShape.php
+++ b/src/PseudoTypes/ArrayShape.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @link      http://phpdoc.org
+ *
+ */
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\PseudoType;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\ArrayKey;
+use phpDocumentor\Reflection\Types\Mixed_;
+
+use function implode;
+
+/** @psalm-immutable */
+class ArrayShape implements PseudoType
+{
+    /** @var ArrayShapeItem[] */
+    private array $items;
+
+    public function __construct(ArrayShapeItem ...$items)
+    {
+        $this->items = $items;
+    }
+
+    public function underlyingType(): Type
+    {
+        return new Array_(new Mixed_(), new ArrayKey());
+    }
+
+    public function __toString(): string
+    {
+        return 'array{' . implode(', ', $this->items) . '}';
+    }
+}

--- a/src/PseudoTypes/ArrayShapeItem.php
+++ b/src/PseudoTypes/ArrayShapeItem.php
@@ -1,0 +1,62 @@
+<?php
+/*
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @link      http://phpdoc.org
+ *
+ */
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Mixed_;
+
+use function sprintf;
+
+final class ArrayShapeItem
+{
+    private ?string $key;
+    private Type $value;
+    private bool $optional;
+
+    public function __construct(?string $key, ?Type $value, bool $optional)
+    {
+        $this->key = $key;
+        $this->value = $value ?? new Mixed_();
+        $this->optional = $optional;
+    }
+
+    public function getKey(): ?string
+    {
+        return $this->key;
+    }
+
+    public function getValue(): Type
+    {
+        return $this->value;
+    }
+
+    public function isOptional(): bool
+    {
+        return $this->optional;
+    }
+
+    public function __toString(): string
+    {
+        if ($this->key !== null) {
+            return sprintf(
+                '%s%s: %s',
+                $this->key,
+                $this->optional ? '?' : '',
+                (string) $this->value
+            );
+        }
+
+        return (string) $this->value;
+    }
+}

--- a/src/PseudoTypes/ConstExpression.php
+++ b/src/PseudoTypes/ConstExpression.php
@@ -1,0 +1,54 @@
+<?php
+/*
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @link      http://phpdoc.org
+ *
+ */
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\PseudoType;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Mixed_;
+
+use function sprintf;
+
+/** @psalm-immutable */
+final class ConstExpression implements PseudoType
+{
+    private Fqsen $owner;
+    private string $expression;
+
+    public function __construct(Fqsen $owner, string $expression)
+    {
+        $this->owner = $owner;
+        $this->expression = $expression;
+    }
+
+    public function getOwner(): Fqsen
+    {
+        return $this->owner;
+    }
+
+    public function getExpression(): string
+    {
+        return $this->expression;
+    }
+
+    public function underlyingType(): Type
+    {
+        return new Mixed_();
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('%s::%s', (string) $this->owner, $this->expression);
+    }
+}

--- a/src/PseudoTypes/FloatValue.php
+++ b/src/PseudoTypes/FloatValue.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @link      http://phpdoc.org
+ *
+ */
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\PseudoType;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Float_;
+
+/** @psalm-immutable */
+class FloatValue implements PseudoType
+{
+    private float $value;
+
+    public function __construct(float $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): float
+    {
+        return $this->value;
+    }
+
+    public function underlyingType(): Type
+    {
+        return new Float_();
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->value;
+    }
+}

--- a/src/PseudoTypes/IntegerValue.php
+++ b/src/PseudoTypes/IntegerValue.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @link      http://phpdoc.org
+ *
+ */
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\PseudoType;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Integer;
+
+/** @psalm-immutable */
+final class IntegerValue implements PseudoType
+{
+    private int $value;
+
+    public function __construct(int $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): int
+    {
+        return $this->value;
+    }
+
+    public function underlyingType(): Type
+    {
+        return new Integer();
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->value;
+    }
+}

--- a/src/PseudoTypes/StringValue.php
+++ b/src/PseudoTypes/StringValue.php
@@ -1,0 +1,46 @@
+<?php
+/*
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @link      http://phpdoc.org
+ *
+ */
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\PseudoType;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Float_;
+
+use function sprintf;
+
+/** @psalm-immutable */
+class StringValue implements PseudoType
+{
+    private string $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+
+    public function underlyingType(): Type
+    {
+        return new Float_();
+    }
+
+    public function __toString(): string
+    {
+        return sprintf('"%s"', $this->value);
+    }
+}

--- a/src/Types/AggregatedType.php
+++ b/src/Types/AggregatedType.php
@@ -106,7 +106,7 @@ abstract class AggregatedType implements Type, IteratorAggregate
      */
     private function add(Type $type): void
     {
-        if ($type instanceof self) {
+        if ($type instanceof static) {
             foreach ($type->getIterator() as $subType) {
                 $this->add($subType);
             }

--- a/src/Types/CallableParameter.php
+++ b/src/Types/CallableParameter.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * This file is part of phpDocumentor.
+ *
+ *  For the full copyright and license information, please view the LICENSE
+ *  file that was distributed with this source code.
+ *
+ *  @link      http://phpdoc.org
+ */
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\Types;
+
+use phpDocumentor\Reflection\Type;
+
+/**
+ * Value Object representing a Callable parameters.
+ *
+ * @psalm-immutable
+ */
+final class CallableParameter
+{
+    private Type $type;
+
+    private bool $isReference;
+
+    private bool $isVariadic;
+
+    private bool $isOptional;
+
+    private ?string $name;
+
+    public function __construct(
+        Type $type,
+        ?string $name = null,
+        bool $isReference = false,
+        bool $isVariadic = false,
+        bool $isOptional = false
+    ) {
+        $this->type = $type;
+        $this->isReference = $isReference;
+        $this->isVariadic = $isVariadic;
+        $this->isOptional = $isOptional;
+        $this->name = $name;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+
+    public function getType(): Type
+    {
+        return $this->type;
+    }
+
+    public function isReference(): bool
+    {
+        return $this->isReference;
+    }
+
+    public function isVariadic(): bool
+    {
+        return $this->isVariadic;
+    }
+
+    public function isOptional(): bool
+    {
+        return $this->isOptional;
+    }
+}

--- a/src/Types/Callable_.php
+++ b/src/Types/Callable_.php
@@ -22,6 +22,30 @@ use phpDocumentor\Reflection\Type;
  */
 final class Callable_ implements Type
 {
+    private ?Type $returnType;
+    /** @var CallableParameter[] */
+    private array $parameters;
+
+    /**
+     * @param CallableParameter[] $parameters
+     */
+    public function __construct(array $parameters = [], ?Type $returnType = null)
+    {
+        $this->parameters = $parameters;
+        $this->returnType = $returnType;
+    }
+
+    /** @return CallableParameter[] */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    public function getReturnType(): ?Type
+    {
+        return $this->returnType;
+    }
+
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */

--- a/tests/benchmark/ContextFactoryBench.php
+++ b/tests/benchmark/ContextFactoryBench.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace benchmark;
 
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
 use phpDocumentor\Reflection\Types\ContextFactory;
 
 /**
@@ -20,13 +21,6 @@ final class ContextFactoryBench
 
     /**
      * @Warmup(1)
-     * @Executor(
-     *     "blackfire",
-     *      assertions={
-     *      {"expression"="main.peak_memory < 120Mb", "title"="memory peak"},
-     *      "main.wall_time < 3S"
-     *      }
-     * )
      */
     public function benchCreateContextForNamespace()
     {

--- a/tests/benchmark/TypeResolverBench.php
+++ b/tests/benchmark/TypeResolverBench.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace benchmark;
 
+use PhpBench\Benchmark\Metadata\Annotations\Revs;
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
 use phpDocumentor\Reflection\TypeResolver;
 
 /**
@@ -21,13 +23,6 @@ class TypeResolverBench
     /**
      * @Warmup(2)
      * @Revs(10000)
-     * @Executor(
-     *     "blackfire",
-     *     assertions={
-     *      {"expression"="main.peak_memory < 11kb", "title"="memory peak"},
-     *      "main.wall_time < 300us"
-     *      }
-     * )
      */
     public function benchResolveSingleType() : void
     {
@@ -37,13 +32,6 @@ class TypeResolverBench
     /**
      * @Warmup(2)
      * @Revs(10000)
-     * @Executor(
-     *     "blackfire",
-     *     assertions={
-     *      {"expression"="main.peak_memory < 11kb", "title"="memory peak"},
-     *      "main.wall_time < 0.5ms"
-     *      }
-     * )
      */
     public function benchResolveCompoundType() : void
     {
@@ -53,13 +41,6 @@ class TypeResolverBench
     /**
      * @Warmup(2)
      * @Revs(10000)
-     * @Executor(
-     *     "blackfire",
-     *     assertions={
-     *      {"expression"="main.peak_memory < 11kb", "title"="memory peak"},
-     *      "main.wall_time < 300us"
-     *      }
-     * )
      */
     public function benchResolveArrayType() : void
     {
@@ -69,13 +50,6 @@ class TypeResolverBench
     /**
      * @Warmup(2)
      * @Revs(10000)
-     * @Executor(
-     *     "blackfire",
-     *     assertions={
-     *      {"expression"="main.peak_memory < 11kb", "title"="memory peak"},
-     *      "main.wall_time < 300us"
-     *      }
-     * )
      */
     public function benchResolveCompoundArrayType() : void
     {
@@ -85,13 +59,6 @@ class TypeResolverBench
     /**
      * @Warmup(2)
      * @Revs(10000)
-     * @Executor(
-     *     "blackfire",
-     *     assertions={
-     *      {"expression"="main.peak_memory < 11kb", "title"="memory peak"},
-     *      "main.wall_time < 1ms"
-     *      }
-     * )
      */
     public function benchResolveCompoundArrayWithDefinedTypes() : void
     {

--- a/tests/benchmark/TypeResolverWithContextBench.php
+++ b/tests/benchmark/TypeResolverWithContextBench.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace benchmark;
 
+use PhpBench\Benchmark\Metadata\Annotations\Warmup;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\Types\ContextFactory;
@@ -32,13 +33,6 @@ final class TypeResolverWithContextBench
 
     /**
      * @Warmup(2)
-     * @Executor(
-     *     "blackfire",
-     *     assertions={
-     *      {"expression"="main.peak_memory < 11kb", "title"="memory peak"},
-     *      "main.wall_time < 1ms"
-     *      }
-     * )
      */
     public function benchResolveCompoundArrayWithDefinedTypes() : void
     {
@@ -47,13 +41,6 @@ final class TypeResolverWithContextBench
 
     /**
      * @Warmup(2)
-     * @Executor(
-     *     "blackfire",
-     *     assertions={
-     *      {"expression"="main.peak_memory < 11kb", "title"="memory peak"},
-     *      "main.wall_time < 1ms"
-     *      }
-     * )
      */
     public function benchArrayOfClass() : void
     {

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Reflection;
 
-use InvalidArgumentException;
 use phpDocumentor\Reflection\PseudoTypes\List_;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Collection;
@@ -178,23 +177,6 @@ class CollectionResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testResolvingArrayCollectionWithKeyAndTooManyWhitespace(): void
-    {
-        $this->expectException(InvalidArgumentException::class);
-        $fixture = new TypeResolver();
-
-        $fixture->resolve('array<string,  object|array>', new Context(''));
-    }
-
-    /**
-     * @uses \phpDocumentor\Reflection\Types\Context
-     * @uses \phpDocumentor\Reflection\Types\Compound
-     * @uses \phpDocumentor\Reflection\Types\Collection
-     * @uses \phpDocumentor\Reflection\Types\String_
-     *
-     * @covers ::__construct
-     * @covers ::resolve
-     */
     public function testResolvingCollectionOfCollection(): void
     {
         $fixture = new TypeResolver();
@@ -260,7 +242,7 @@ class CollectionResolverTest extends TestCase
     public function testMissingStartCollection(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected collection operator "<", class name is missing');
+        $this->expectExceptionMessage('Unexpected token "<", expected type at offset 0');
         $fixture = new TypeResolver();
         $fixture->resolve('<string>', new Context(''));
     }
@@ -272,7 +254,7 @@ class CollectionResolverTest extends TestCase
     public function testMissingEndCollection(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Collection: ">" is missing');
+        $this->expectExceptionMessage('Unexpected token "", expected \'>\' at offset 25');
         $fixture = new TypeResolver();
         $fixture->resolve('ArrayObject<object|string', new Context(''));
     }

--- a/tests/unit/IntegerRangeResolverTest.php
+++ b/tests/unit/IntegerRangeResolverTest.php
@@ -83,7 +83,7 @@ class IntegerRangeResolverTest extends TestCase
      * @covers ::__construct
      * @covers ::resolve
      */
-    public function testResolvingIntRangeErrorMisingMaxValue(): void
+    public function testResolvingIntRangeErrorMissingMaxValue(): void
     {
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessage('int<min,max> has not the correct format');
@@ -104,7 +104,7 @@ class IntegerRangeResolverTest extends TestCase
     public function testResolvingIntRangeErrorMisingMinValue(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('int<min,max> has not the correct format');
+        $this->expectExceptionMessage('Unexpected token ",", expected type at offset 4');
 
         $fixture = new TypeResolver();
         $resolvedType = $fixture->resolve('int<,max>', new Context(''));
@@ -140,27 +140,9 @@ class IntegerRangeResolverTest extends TestCase
     public function testResolvingIntRangeErrorMissingEnd(): void
     {
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Unexpected character "max", ">" is missing');
+        $this->expectExceptionMessage('Unexpected token "", expected \'>\' at offset 11');
 
         $fixture = new TypeResolver();
         $resolvedType = $fixture->resolve('int<min,max', new Context(''));
-    }
-
-    /**
-     * @uses \phpDocumentor\Reflection\Types\Context
-     * @uses \phpDocumentor\Reflection\Types\Compound
-     * @uses \phpDocumentor\Reflection\Types\Collection
-     * @uses \phpDocumentor\Reflection\Types\String_
-     *
-     * @covers ::__construct
-     * @covers ::resolve
-     */
-    public function testResolvingIntRangeErrorFormat(): void
-    {
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('int<min,max> has not the correct format');
-
-        $fixture = new TypeResolver();
-        $resolvedType = $fixture->resolve('int<min,max,>', new Context(''));
     }
 }

--- a/tests/unit/Types/CompoundTest.php
+++ b/tests/unit/Types/CompoundTest.php
@@ -143,4 +143,34 @@ final class CompoundTest extends TestCase
             $this->assertSame($types[$index], $type);
         }
     }
+
+    /**
+     * @uses \phpDocumentor\Reflection\Types\Integer
+     * @uses \phpDocumentor\Reflection\Types\Boolean
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testCompoundIsMergedWithCompound(): void
+    {
+        $compound = new Compound([new Integer(), new Compound([new Integer(), new Boolean()])]);
+
+        $this->assertCount(2, iterator_to_array($compound));
+        $this->assertSame('int|bool', (string) $compound);
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\Types\Integer
+     * @uses \phpDocumentor\Reflection\Types\Boolean
+     *
+     * @covers ::__construct
+     * @covers ::__toString
+     */
+    public function testCompoundIsMergedOnMergedWithIntersection(): void
+    {
+        $compound = new Compound([new Integer(), new Intersection([new Integer(), new Boolean()])]);
+
+        $this->assertCount(2, iterator_to_array($compound));
+        $this->assertSame('int|int&bool', (string) $compound);
+    }
 }

--- a/tests/unit/Types/ContextFactoryTest.php
+++ b/tests/unit/Types/ContextFactoryTest.php
@@ -180,7 +180,7 @@ PHP
                 'Assert' => Assert::class,
                 'e' => e::class,
                 ReflectionClass::class => ReflectionClass::class,
-                'stdClass' => 'stdClass',
+                \stdClass::class => \stdClass::class,
             ];
 
             $actual = $context->getNamespaceAliases();


### PR DESCRIPTION
Types are no longer parsed by this library. We do now use the phpstan
parser to parse types. Having support for more advanced type definitions
without the burden to support all parser logic.

In this commit I do introduce support for:
- array shapes
- constant expressions like integers, strings, and floats
- constant expressions for enums and class constants
- Callable support with and without params and return types.

A new set of unittests have been added to ensure everything keeps working as
expected.

Fixes #155 
Fixes #173
Refs #157 this pr should be revisted