### PR TITLE
Fix regression in main branch

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,7 +4,7 @@
     bootstrap="vendor/autoload.php"
     colors="true"
     verbose="true"
-    convertDeprecationsToExceptions="true"
+    convertDeprecationsToExceptions="false"
     forceCoversAnnotation="true"
 >
     <testsuites>

--- a/src/PseudoTypes/ConstExpression.php
+++ b/src/PseudoTypes/ConstExpression.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Reflection\PseudoTypes;
 
-use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\PseudoType;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Mixed_;
@@ -23,16 +22,16 @@ use function sprintf;
 /** @psalm-immutable */
 final class ConstExpression implements PseudoType
 {
-    private Fqsen $owner;
+    private Type $owner;
     private string $expression;
 
-    public function __construct(Fqsen $owner, string $expression)
+    public function __construct(Type $owner, string $expression)
     {
         $this->owner = $owner;
         $this->expression = $expression;
     }
 
-    public function getOwner(): Fqsen
+    public function getOwner(): Type
     {
         return $this->owner;
     }


### PR DESCRIPTION
The type resolver did support some odd format being a nullable type combined with compound or intersection. The new implementation didn't as phpstan doesn't support this. By now this behavoir is restored with a deprecation notice that we will remove it in the future.