### PR TITLE
Adding getter for token in AggregatedType

### DIFF
--- a/src/Types/AggregatedType.php
+++ b/src/Types/AggregatedType.php
@@ -51,6 +51,13 @@ abstract class AggregatedType implements Type, IteratorAggregate
     }
 
     /**
+     * Returns the token used to separate the types
+     */
+    public function getToken(): string {
+        return $this->token;
+    }
+
+    /**
      * Returns the type at the given index.
      */
     public function get(int $index): ?Type


### PR DESCRIPTION
Needed for draft-PR in phpDocumentor: https://github.com/phpDocumentor/phpDocumentor/pull/3393

Adds an getter for the token (seperator) in AggregatedType.