### PR TITLE
Add non-empty-list pseudo-type

### DIFF
--- a/src/PseudoTypes/NonEmptyList.php
+++ b/src/PseudoTypes/NonEmptyList.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\PseudoType;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Array_;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\Mixed_;
+
+/**
+ * Value Object representing the type 'non-empty-list'.
+ *
+ * @psalm-immutable
+ */
+final class NonEmptyList extends Array_ implements PseudoType
+{
+    public function underlyingType(): Type
+    {
+        return new Array_();
+    }
+
+    public function __construct(?Type $valueType = null)
+    {
+        parent::__construct($valueType, new Integer());
+    }
+
+    /**
+     * Returns a rendered output of the Type as it would be used in a DocBlock.
+     */
+    public function __toString(): string
+    {
+        if ($this->valueType instanceof Mixed_) {
+            return 'non-empty-list';
+        }
+
+        return 'non-empty-list<' . $this->valueType . '>';
+    }
+}

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -27,6 +27,7 @@ use phpDocumentor\Reflection\PseudoTypes\List_;
 use phpDocumentor\Reflection\PseudoTypes\LiteralString;
 use phpDocumentor\Reflection\PseudoTypes\LowercaseString;
 use phpDocumentor\Reflection\PseudoTypes\NegativeInteger;
+use phpDocumentor\Reflection\PseudoTypes\NonEmptyList;
 use phpDocumentor\Reflection\PseudoTypes\NonEmptyLowercaseString;
 use phpDocumentor\Reflection\PseudoTypes\NonEmptyString;
 use phpDocumentor\Reflection\PseudoTypes\Numeric_;
@@ -157,6 +158,7 @@ final class TypeResolver
         'iterable' => Iterable_::class,
         'never' => Never_::class,
         'list' => List_::class,
+        'non-empty-list' => NonEmptyList::class,
     ];
 
     /** @psalm-readonly */
@@ -330,6 +332,11 @@ final class TypeResolver
 
             case 'list':
                 return new List_(
+                    $this->createType($type->genericTypes[0], $context)
+                );
+
+            case 'non-empty-list':
+                return new NonEmptyList(
                     $this->createType($type->genericTypes[0], $context)
                 );
 

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection;
 
 use phpDocumentor\Reflection\PseudoTypes\List_;
+use phpDocumentor\Reflection\PseudoTypes\NonEmptyList;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Collection;
 use phpDocumentor\Reflection\Types\Compound;
@@ -312,6 +313,30 @@ class CollectionResolverTest extends TestCase
 
         $this->assertInstanceOf(List_::class, $resolvedType);
         $this->assertSame('list<string>', (string) $resolvedType);
+
+        $valueType = $resolvedType->getValueType();
+
+        $keyType = $resolvedType->getKeyType();
+
+        $this->assertInstanceOf(String_::class, $valueType);
+        $this->assertInstanceOf(Integer::class, $keyType);
+    }
+
+    /**
+     * @uses \phpDocumentor\Reflection\Types\Context
+     * @uses \phpDocumentor\Reflection\Types\String_
+     *
+     * @covers ::__construct
+     * @covers ::resolve
+     */
+    public function testResolvingNonEmptyList(): void
+    {
+        $fixture = new TypeResolver();
+
+        $resolvedType = $fixture->resolve('non-empty-list<string>', new Context(''));
+
+        $this->assertInstanceOf(NonEmptyList::class, $resolvedType);
+        $this->assertSame('non-empty-list<string>', (string) $resolvedType);
 
         $valueType = $resolvedType->getValueType();
 

--- a/tests/unit/PseudoTypes/NonEmptyListTest.php
+++ b/tests/unit/PseudoTypes/NonEmptyListTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\Types\Compound;
+use phpDocumentor\Reflection\Types\Integer;
+use phpDocumentor\Reflection\Types\Mixed_;
+use phpDocumentor\Reflection\Types\String_;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\NonEmptyList
+ */
+class NonEmptyListTest extends TestCase
+{
+    /**
+     * @dataProvider provideArrays
+     * @covers ::__toString
+     */
+    public function testArrayStringifyCorrectly(NonEmptyList $array, string $expectedString): void
+    {
+        $this->assertSame($expectedString, (string) $array);
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function provideArrays(): array
+    {
+        return [
+            'simple non-empty-list' => [new NonEmptyList(), 'non-empty-list'],
+            'non-empty-list of mixed' => [new NonEmptyList(new Mixed_()), 'non-empty-list'],
+            'non-empty-list of single type' => [new NonEmptyList(new String_()), 'non-empty-list<string>'],
+            'non-empty-list of compound type' => [new NonEmptyList(new Compound([new Integer(), new String_()])), 'non-empty-list<int|string>'],
+        ];
+    }
+}

--- a/tests/unit/PseudoTypes/NonEmptyListTest.php
+++ b/tests/unit/PseudoTypes/NonEmptyListTest.php
@@ -42,7 +42,8 @@ class NonEmptyListTest extends TestCase
             'simple non-empty-list' => [new NonEmptyList(), 'non-empty-list'],
             'non-empty-list of mixed' => [new NonEmptyList(new Mixed_()), 'non-empty-list'],
             'non-empty-list of single type' => [new NonEmptyList(new String_()), 'non-empty-list<string>'],
-            'non-empty-list of compound type' => [new NonEmptyList(new Compound([new Integer(), new String_()])), 'non-empty-list<int|string>'],
+            'non-empty-list of compound type' =>
+                [new NonEmptyList(new Compound([new Integer(), new String_()])), 'non-empty-list<int|string>'],
         ];
     }
 }

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -25,6 +25,7 @@ use phpDocumentor\Reflection\PseudoTypes\List_;
 use phpDocumentor\Reflection\PseudoTypes\LiteralString;
 use phpDocumentor\Reflection\PseudoTypes\LowercaseString;
 use phpDocumentor\Reflection\PseudoTypes\NegativeInteger;
+use phpDocumentor\Reflection\PseudoTypes\NonEmptyList;
 use phpDocumentor\Reflection\PseudoTypes\NonEmptyLowercaseString;
 use phpDocumentor\Reflection\PseudoTypes\NonEmptyString;
 use phpDocumentor\Reflection\PseudoTypes\Numeric_;
@@ -784,6 +785,7 @@ class TypeResolverTest extends TestCase
             ['never', Never_::class],
             ['literal-string', LiteralString::class],
             ['list', List_::class],
+            ['non-empty-list', NonEmptyList::class],
         ];
     }
 


### PR DESCRIPTION
Add support for 'non-empty-list'.

See https://phpstan.org/writing-php-code/phpdoc-types#lists

Symfony's Serializer also uses the TypeResolver library to determine how to serialize 'list's, but currently doesn't support 'non-empty-list' due to it missing here. This resolves that, which means arrays of objects can correctly be serialized into that array of objects, and vice-versa.