### PR TITLE
Change underlying type for StringValue pseudo type

### DIFF
--- a/src/PseudoTypes/StringValue.php
+++ b/src/PseudoTypes/StringValue.php
@@ -15,7 +15,7 @@ namespace phpDocumentor\Reflection\PseudoTypes;
 
 use phpDocumentor\Reflection\PseudoType;
 use phpDocumentor\Reflection\Type;
-use phpDocumentor\Reflection\Types\Float_;
+use phpDocumentor\Reflection\Types\String_;
 
 use function sprintf;
 
@@ -36,7 +36,7 @@ class StringValue implements PseudoType
 
     public function underlyingType(): Type
     {
-        return new Float_();
+        return new String_();
     }
 
     public function __toString(): string


### PR DESCRIPTION
Seems that it is a mistake that `StringValue` is `Float_`

In my project I use `symfony/serializer` with `phpdocumentor/reflection-docblock` and after upgrade the deserialization of this code sample does not work correctly, because the underlying type of `$order` is not a String_

```php
final class OrderBy
{
    /**
     * @param 'ASC'|'DESC' $order
     */
    public function __construct(
        private readonly string $order,
    ) {
    }

    /**
     * @return 'ASC'|'DESC'
     */
    public function getOrder(): string
    {
        return $this->order;
    }
}
```