### PR TITLE
Update parser token constant values to ints instead of strings

### DIFF
--- a/src/Types/ContextFactory.php
+++ b/src/Types/ContextFactory.php
@@ -49,11 +49,11 @@ use const T_TRAIT;
 use const T_USE;
 
 if (!defined('T_NAME_QUALIFIED')) {
-    define('T_NAME_QUALIFIED', 'T_NAME_QUALIFIED');
+    define('T_NAME_QUALIFIED', 10001);
 }
 
 if (!defined('T_NAME_FULLY_QUALIFIED')) {
-    define('T_NAME_FULLY_QUALIFIED', 'T_NAME_FULLY_QUALIFIED');
+    define('T_NAME_FULLY_QUALIFIED', 10002);
 }
 
 /**


### PR DESCRIPTION
I just came across a incompatibility with this package, and `nikic/php-parser`.

This package defines a few "parser token" constants here: https://github.com/phpDocumentor/TypeResolver/blob/e03361ca67e7e88452c46c28caca34309be40f53/src/Types/ContextFactory.php#L51-L57

`nikic/php-parser` does something similar (but perhaps more comprehensive?) here: https://github.com/nikic/PHP-Parser/blob/master/lib/PhpParser/compatibility_tokens.php
The `nikic/php-parser` defines a superset of the tokens defined in this package, with the key difference being they are given `int` values instead of `string` values.

This leads to an issue, where if the code in this package is loaded first, the few tokens that this package has defined will have string values, and break when being used with `nikic/php-parser` as they expect integer values.

The PHP documentation seems to indicate that user land defined parser tokens should indeed be `int` values: https://www.php.net/manual/en/tokens.php

