### PR TITLE
Be able to run examples whatever current directory is

### DIFF
--- a/examples/01-resolving-simple-types.php
+++ b/examples/01-resolving-simple-types.php
@@ -2,7 +2,7 @@
 
 use phpDocumentor\Reflection\TypeResolver;
 
-require '../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 $typeResolver = new TypeResolver();
 

--- a/examples/02-resolving-classes.php
+++ b/examples/02-resolving-classes.php
@@ -3,7 +3,7 @@
 use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\TypeResolver;
 
-require '../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 $typeResolver = new TypeResolver();
 

--- a/examples/03-resolving-all-elements.php
+++ b/examples/03-resolving-all-elements.php
@@ -3,7 +3,7 @@
 use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\FqsenResolver;
 
-require '../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 $fqsenResolver = new FqsenResolver();
 

--- a/examples/04-discovering-the-context-using-class-reflection.php
+++ b/examples/04-discovering-the-context-using-class-reflection.php
@@ -4,7 +4,7 @@ use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\ContextFactory;
 
-require '../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 require 'Classy.php';
 
 $typeResolver = new TypeResolver();

--- a/examples/05-discovering-the-context-using-method-reflection.php
+++ b/examples/05-discovering-the-context-using-method-reflection.php
@@ -4,7 +4,7 @@ use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\ContextFactory;
 
-require '../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 require 'Classy.php';
 
 $typeResolver = new TypeResolver();

--- a/examples/06-discovering-the-context-using-file-contents.php
+++ b/examples/06-discovering-the-context-using-file-contents.php
@@ -4,13 +4,13 @@ use phpDocumentor\Reflection\FqsenResolver;
 use phpDocumentor\Reflection\TypeResolver;
 use phpDocumentor\Reflection\Types\ContextFactory;
 
-require '../vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 $typeResolver = new TypeResolver();
 $fqsenResolver = new FqsenResolver();
 
 $contextFactory = new ContextFactory();
-$context = $contextFactory->createForNamespace('My\Example', file_get_contents('Classy.php'));
+$context = $contextFactory->createForNamespace('My\Example', file_get_contents(__DIR__ . '/Classy.php'));
 
 // Class named: \phpDocumentor\Reflection\Types\Resolver
 var_dump((string)$typeResolver->resolve('Types\Resolver', $context));


### PR DESCRIPTION
Hello 

With recent [problem](https://github.com/sebastianbergmann/phpunit/issues/5712) found when using PHPUnit v9.6 PHAR version, I've rediscovered `phpDocumentor/TypeResolver`.

## Context

I've forked the repo, and install all dependencies with `composer install` because there is a `composer.lock`.

BTW, do you tell us why dependencies seems very outdated (composer.lock was modified a year ago : Mar 12, 2023 on branch 1.x) while there is at least a recent version 1.8.1 (2 days ago) ?

Chunk of `composer outdated` command results :

```text
Direct dependencies required in composer.json:
doctrine/deprecations            v1.0.0  1.1.3   A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to d...
phpbench/phpbench                1.2.7   1.2.14  PHP Benchmarking Framework
phpstan/extension-installer      1.1.0   1.3.1   Composer plugin for automatic installation of PHPStan extensions
phpstan/phpdoc-parser            1.13.0  1.25.0  PHPDoc parser with support for nullable, intersection and generic types
phpstan/phpstan                  1.8.2   1.10.59 PHPStan - PHP Static Analysis Tool
phpstan/phpstan-phpunit          1.1.1   1.3.15  PHPUnit extensions and rules for PHPStan
phpunit/phpunit                  9.5.21  9.6.16  The PHP Unit Testing framework.
rector/rector                    0.13.9  1.0.1   Instant Upgrade and Automated Refactoring of any PHP code
vimeo/psalm                      v4.25.0 5.22.1  A static analysis tool for finding errors in PHP applications
```

## Try it

With current directory is root of the forked repo copy, I've tried to run examples : 

```shell
devilbox@php-8.3.3 in /shared/backups/github/TypeResolver $ php examples/01-resolving-simple-types.php
```

But I got : 

```text

Warning: require(../vendor/autoload.php): Failed to open stream: No such file or directory in /shared/backups/github/TypeResolver/examples/01-resolving-simple-types.php on line 5

Call Stack:
    0.0001     934048   1. {main}() /shared/backups/github/TypeResolver/examples/01-resolving-simple-types.php:0


Fatal error: Uncaught Error: Failed opening required '../vendor/autoload.php' (include_path='.:/usr/local/lib/php') in /shared/backups/github/TypeResolver/examples/01-resolving-simple-types.php on line 5

Error: Failed opening required '../vendor/autoload.php' (include_path='.:/usr/local/lib/php') in /shared/backups/github/TypeResolver/examples/01-resolving-simple-types.php on line 5

Call Stack:
    0.0001     934048   1. {main}() /shared/backups/github/TypeResolver/examples/01-resolving-simple-types.php:0

```

While, expected results are : 

```text
\phpDocumentor\Reflection\Types\Compound::__set_state(array(
   'types' =>
  array (
    0 =>
    \phpDocumentor\Reflection\Types\String_::__set_state(array(
    )),
    1 =>
    \phpDocumentor\Reflection\Types\Integer::__set_state(array(
    )),
  ),
   'token' => '|',
))/shared/backups/github/TypeResolver/examples/01-resolving-simple-types.php:13:
string(10) "string|int"
```

This PR solve the problem, whatever current dir is !



 