### PR TITLE
Correct documentation reference

### DIFF
--- a/src/Types/Context.php
+++ b/src/Types/Context.php
@@ -28,7 +28,7 @@ use function trim;
  * own application it is possible to generate a Context class using the ContextFactory; this will analyze the file in
  * which an associated class resides for its namespace and imports.
  *
- * @see ContextFactory::createFromClassReflector()
+ * @see ContextFactory::createFromReflector()
  * @see ContextFactory::createForNamespace()
  *
  * @psalm-immutable


### PR DESCRIPTION
In https://github.com/phpDocumentor/TypeResolver/commit/d415ee87513a4c304c6e0fe33011c86f6427e568 the method `createFromClassReflector` was renamed to `createFromReflector`