### PR TITLE
Fix handling of array shapes without keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # IDE Shizzle; it is recommended to use a global .gitignore for this but since this is an OSS project we want to make
 # it easy to contribute
 .idea
+.vscode
 /nbproject/private/
 .buildpath
 .project

--- a/src/PseudoTypes/ShapeItem.php
+++ b/src/PseudoTypes/ShapeItem.php
@@ -42,7 +42,7 @@ abstract class ShapeItem
 
     public function __toString(): string
     {
-        if ($this->key !== null) {
+        if ($this->key !== null && $this->key !== '') {
             return sprintf(
                 '%s%s: %s',
                 $this->key,

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -255,7 +255,7 @@ final class TypeResolver
                             ...array_map(
                                 function (ArrayShapeItemNode $item) use ($context): ArrayShapeItem {
                                     return new ArrayShapeItem(
-                                        (string) $item->keyName,
+                                        $item->keyName !== null ? (string) $item->keyName : null,
                                         $this->createType($item->valueType, $context),
                                         $item->optional
                                     );

--- a/tests/unit/PseudoTypes/ArrayShapeTest.php
+++ b/tests/unit/PseudoTypes/ArrayShapeTest.php
@@ -23,4 +23,43 @@ class ArrayShapeTest extends TestCase
 
         $this->assertSame([$item1, $item2], $arrayShape->getItems());
     }
+
+    /**
+     * @dataProvider provideToStringData
+     * @covers ::__toString
+     */
+    public function testToString(string $expectedResult, ArrayShape $arrayShape): void
+    {
+        $this->assertSame($expectedResult, (string) $arrayShape);
+    }
+
+    /**
+     * @return array<string, array{string, ArrayShape}>
+     */
+    public static function provideToStringData(): array
+    {
+        return [
+            'with keys' => [
+                'array{foo: true, bar?: false}',
+                new ArrayShape(
+                    new ArrayShapeItem('foo', new True_(), false),
+                    new ArrayShapeItem('bar', new False_(), true)
+                ),
+            ],
+            'with empty keys' => [
+                'array{true, false}',
+                new ArrayShape(
+                    new ArrayShapeItem('', new True_(), false),
+                    new ArrayShapeItem('', new False_(), false)
+                ),
+            ],
+            'without keys' => [
+                'array{true, false}',
+                new ArrayShape(
+                    new ArrayShapeItem(null, new True_(), false),
+                    new ArrayShapeItem(null, new False_(), false)
+                ),
+            ],
+        ];
+    }
 }

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -1151,6 +1151,13 @@ class TypeResolverTest extends TestCase
                 ),
             ],
             [
+                'array{string, int}',
+                new ArrayShape(
+                    new ArrayShapeItem(null, new String_(), false),
+                    new ArrayShapeItem(null, new Integer(), false)
+                ),
+            ],
+            [
                 'array{foo?: string, bar: int}',
                 new ArrayShape(
                     new ArrayShapeItem('foo', new String_(), true),


### PR DESCRIPTION
### Problem

Arrays of the form `array{string, string, string}` are converted to `array{: string, : string, : string}`.

### Solution

The solution consists of two parts:

1. Do not convert `null` to an empty string in `TypeResolver`.
2. When the key is an empty string, do not display it in `ShapeItem`. This is an additional safety net for the future.
