### PR TITLE
Add `.editorconfig`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,3 @@
-# editorconfig.org
-
 root = true
 
 [*]
@@ -9,3 +7,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+[*.yml]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 /.github/ export-ignore
 /examples/ export-ignore
 /tests/ export-ignore
+/.editorconfig export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.yamllint.yaml export-ignore


### PR DESCRIPTION
I think this will be very useful. At the very least, we won't have to worry about extra spaces anymore 😄
