### PR TITLE
Exclude commits with CS changes from Git Blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,13 +1,7 @@
 # CS: no whitespace before return type colon
 6937c3bf9f57533b310c28c1758f4af6bd777f92
-# CS: blank line between different use statement types
-6a038945051bb17e760620930dd1d91aa041647f
-# CS: import all things
-53bb2a98396eb2dcbe56039235e1aa4c78003033
 # CS: miscellaneous other whitespace fixes
 92a009284c653e8576ee544191f2167f97c93aed
-# CS: docblock tag grouping
-a2f72753663b4e9eb0bcce74174044d9a92d86ff
 # Fix style issues
 0339a6b726db84790d94794e36f502c52e0e518a
 # CS fixes

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,22 @@
+# CS: no whitespace before return type colon
+6937c3bf9f57533b310c28c1758f4af6bd777f92
+# CS: blank line between different use statement types
+6a038945051bb17e760620930dd1d91aa041647f
+# CS: import all things
+53bb2a98396eb2dcbe56039235e1aa4c78003033
+# CS: miscellaneous other whitespace fixes
+92a009284c653e8576ee544191f2167f97c93aed
+# CS: docblock tag grouping
+a2f72753663b4e9eb0bcce74174044d9a92d86ff
+# Fix style issues
+0339a6b726db84790d94794e36f502c52e0e518a
+# CS fixes
+2e32a6d48972b2c1976ed5d8967145b6cec4a4a9
+# CS fixes
+e64841657859b6a3d1ecf01d6922ce1548ad7382
+# fix code style
+81dea8effddb6afc070552d95b8f5bbc2589fe10
+# Style fixes
+0cbfc1c752b9fae8c7a0be740e5d6af496463e1e
+# Apply doctrine coding standards
+d0e860a40b8199a0d5166023bc3764eed7af7d83

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 /examples/ export-ignore
 /tests/ export-ignore
 /.editorconfig export-ignore
+/.git-blame-ignore-revs export-ignore
 /.gitattributes export-ignore
 /.gitignore export-ignore
 /.yamllint.yaml export-ignore


### PR DESCRIPTION
Sometimes it's difficult to search for something using Git Blame because many lines were changed during a global code style change. I suggest excluding several commits with style changes to make Git Blame more informative.

I just ran a quick check on the commits. It might be necessary to exclude some more commits.

### Example

#### Before

<img width="1074" height="534" alt="image" src="https://github.com/user-attachments/assets/a232d66b-080c-46dd-b505-63bbd285c26d" />

#### After

<img width="1073" height="533" alt="image" src="https://github.com/user-attachments/assets/d0f0a47e-c5d8-4854-8575-52db3b037359" />

