### PR TITLE
Add support for generics in `Static_` and `Self_`

### DIFF
--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -628,14 +628,7 @@ final class TypeResolver
     /** @param TypeNode[] $typeNodes */
     private function createArray(array $typeNodes, Context $context): Array_
     {
-        $types = array_reverse(
-            array_map(
-                function (TypeNode $node) use ($context): Type {
-                    return $this->createType($node, $context);
-                },
-                $typeNodes
-            )
-        );
+        $types = array_reverse($this->createTypesByTypeNodes($typeNodes, $context));
 
         if (isset($types[1]) === false) {
             return new Array_(...$types);

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -713,6 +713,7 @@ final class TypeResolver
 
     /**
      * @param TypeNode[] $nodes
+     *
      * @return Type[]
      */
     private function createTypesByTypeNodes(array $nodes, Context $context): array

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -434,16 +434,7 @@ final class TypeResolver
                 return new IntegerRange((string) $type->genericTypes[0], (string) $type->genericTypes[1]);
 
             case 'iterable':
-                return new Iterable_(
-                    ...array_reverse(
-                        array_map(
-                            function (TypeNode $genericType) use ($context): Type {
-                                return $this->createType($genericType, $context);
-                            },
-                            $type->genericTypes
-                        )
-                    )
-                );
+                return new Iterable_(...array_reverse($this->createTypesByTypeNodes($type->genericTypes, $context)));
 
             case 'key-of':
                 return new KeyOf($this->createType($type->genericTypes[0], $context));
@@ -452,17 +443,16 @@ final class TypeResolver
                 return new ValueOf($this->createType($type->genericTypes[0], $context));
 
             case 'int-mask':
-                return new IntMask(
-                    ...array_map(
-                        function (TypeNode $genericType) use ($context): Type {
-                            return $this->createType($genericType, $context);
-                        },
-                        $type->genericTypes
-                    )
-                );
+                return new IntMask(...$this->createTypesByTypeNodes($type->genericTypes, $context));
 
             case 'int-mask-of':
                 return new IntMaskOf($this->createType($type->genericTypes[0], $context));
+
+            case 'static':
+                return new Static_(...$this->createTypesByTypeNodes($type->genericTypes, $context));
+
+            case 'self':
+                return new Self_(...$this->createTypesByTypeNodes($type->genericTypes, $context));
 
             default:
                 $collectionType = $this->createType($type->type, $context);
@@ -472,14 +462,7 @@ final class TypeResolver
 
                 return new Collection(
                     $collectionType->getFqsen(),
-                    ...array_reverse(
-                        array_map(
-                            function (TypeNode $genericType) use ($context): Type {
-                                return $this->createType($genericType, $context);
-                            },
-                            $type->genericTypes
-                        )
-                    )
+                    ...array_reverse($this->createTypesByTypeNodes($type->genericTypes, $context))
                 );
         }
     }
@@ -726,5 +709,19 @@ final class TypeResolver
         }
 
         return $type;
+    }
+
+    /**
+     * @param TypeNode[] $nodes
+     * @return Type[]
+     */
+    private function createTypesByTypeNodes(array $nodes, Context $context): array
+    {
+        return array_map(
+            function (TypeNode $node) use ($context): Type {
+                return $this->createType($node, $context);
+            },
+            $nodes
+        );
     }
 }

--- a/src/Types/Self_.php
+++ b/src/Types/Self_.php
@@ -15,6 +15,8 @@ namespace phpDocumentor\Reflection\Types;
 
 use phpDocumentor\Reflection\Type;
 
+use function implode;
+
 /**
  * Value Object representing the 'self' type.
  *

--- a/src/Types/Self_.php
+++ b/src/Types/Self_.php
@@ -24,11 +24,31 @@ use phpDocumentor\Reflection\Type;
  */
 final class Self_ implements Type
 {
+    /** @var Type[] */
+    private $genericTypes;
+
+    public function __construct(Type ...$genericTypes)
+    {
+        $this->genericTypes = $genericTypes;
+    }
+
+    /**
+     * @return Type[]
+     */
+    public function getGenericTypes(): array
+    {
+        return $this->genericTypes;
+    }
+
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
     public function __toString(): string
     {
+        if ($this->genericTypes) {
+            return 'self<' . implode(', ', $this->genericTypes) . '>';
+        }
+
         return 'self';
     }
 }

--- a/src/Types/Static_.php
+++ b/src/Types/Static_.php
@@ -15,6 +15,8 @@ namespace phpDocumentor\Reflection\Types;
 
 use phpDocumentor\Reflection\Type;
 
+use function implode;
+
 /**
  * Value Object representing the 'static' type.
  *

--- a/src/Types/Static_.php
+++ b/src/Types/Static_.php
@@ -29,11 +29,31 @@ use phpDocumentor\Reflection\Type;
  */
 final class Static_ implements Type
 {
+    /** @var Type[] */
+    private $genericTypes;
+
+    public function __construct(Type ...$genericTypes)
+    {
+        $this->genericTypes = $genericTypes;
+    }
+
+    /**
+     * @return Type[]
+     */
+    public function getGenericTypes(): array
+    {
+        return $this->genericTypes;
+    }
+
     /**
      * Returns a rendered output of the Type as it would be used in a DocBlock.
      */
     public function __toString(): string
     {
+        if ($this->genericTypes) {
+            return 'static<' . implode(', ', $this->genericTypes) . '>';
+        }
+
         return 'static';
     }
 }

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -981,8 +981,28 @@ class TypeResolverTest extends TestCase
                 ),
             ],
             [
+                'static',
+                new Static_(),
+            ],
+            [
+                'static<FirstClass, SecondClass, ThirdClass>',
+                new Static_(
+                    new Object_(new Fqsen('\\phpDocumentor\\FirstClass')),
+                    new Object_(new Fqsen('\\phpDocumentor\\SecondClass')),
+                    new Object_(new Fqsen('\\phpDocumentor\\ThirdClass')),
+                ),
+            ],
+            [
                 'self',
                 new Self_(),
+            ],
+            [
+                'self<FirstClass, SecondClass, ThirdClass>',
+                new Self_(
+                    new Object_(new Fqsen('\\phpDocumentor\\FirstClass')),
+                    new Object_(new Fqsen('\\phpDocumentor\\SecondClass')),
+                    new Object_(new Fqsen('\\phpDocumentor\\ThirdClass')),
+                ),
             ],
             [
                 '($size is positive-int ? non-empty-array : array)',

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -985,24 +985,8 @@ class TypeResolverTest extends TestCase
                 new Static_(),
             ],
             [
-                'static<FirstClass, SecondClass, ThirdClass>',
-                new Static_(
-                    new Object_(new Fqsen('\\phpDocumentor\\FirstClass')),
-                    new Object_(new Fqsen('\\phpDocumentor\\SecondClass')),
-                    new Object_(new Fqsen('\\phpDocumentor\\ThirdClass')),
-                ),
-            ],
-            [
                 'self',
                 new Self_(),
-            ],
-            [
-                'self<FirstClass, SecondClass, ThirdClass>',
-                new Self_(
-                    new Object_(new Fqsen('\\phpDocumentor\\FirstClass')),
-                    new Object_(new Fqsen('\\phpDocumentor\\SecondClass')),
-                    new Object_(new Fqsen('\\phpDocumentor\\ThirdClass')),
-                ),
             ],
             [
                 '($size is positive-int ? non-empty-array : array)',
@@ -1128,6 +1112,26 @@ class TypeResolverTest extends TestCase
             [
                 'int-mask-of<Foo::INT_*>',
                 new IntMaskOf(new ConstExpression(new Object_(new Fqsen('\\phpDocumentor\\Foo')), 'INT_*')),
+            ],
+            [
+                'iterable<int, string>',
+                new Iterable_(new String_(), new Integer()),
+            ],
+            [
+                'static<FirstClass, SecondClass, ThirdClass>',
+                new Static_(
+                    new Object_(new Fqsen('\\phpDocumentor\\FirstClass')),
+                    new Object_(new Fqsen('\\phpDocumentor\\SecondClass')),
+                    new Object_(new Fqsen('\\phpDocumentor\\ThirdClass')),
+                ),
+            ],
+            [
+                'self<FirstClass, SecondClass, ThirdClass>',
+                new Self_(
+                    new Object_(new Fqsen('\\phpDocumentor\\FirstClass')),
+                    new Object_(new Fqsen('\\phpDocumentor\\SecondClass')),
+                    new Object_(new Fqsen('\\phpDocumentor\\ThirdClass')),
+                ),
             ],
         ];
     }

--- a/tests/unit/Types/SelfTest.php
+++ b/tests/unit/Types/SelfTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\Types;
 
 use phpDocumentor\Reflection\Fqsen;
-use phpDocumentor\Reflection\Types\Object_;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/unit/Types/SelfTest.php
+++ b/tests/unit/Types/SelfTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\Types;
+
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Types\Object_;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Reflection\Types\Self_
+ */
+class SelfTest extends TestCase
+{
+    /**
+     * @covers ::getGenericTypes
+     */
+    public function testCreate(): void
+    {
+        $genericTypes = [
+            new Object_(new Fqsen('\\phpDocumentor\\FirstClass')),
+            new Object_(new Fqsen('\\phpDocumentor\\SecondClass')),
+            new Object_(new Fqsen('\\phpDocumentor\\ThirdClass')),
+        ];
+
+        $type = new Self_(...$genericTypes);
+
+        $this->assertSame($genericTypes, $type->getGenericTypes());
+    }
+
+    /**
+     * @dataProvider provideToStringData
+     * @covers ::__toString
+     */
+    public function testToString(string $expectedResult, Self_ $type): void
+    {
+        $this->assertSame($expectedResult, (string) $type);
+    }
+
+    /**
+     * @return array<string, array{string, OffsetAccess}>
+     */
+    public static function provideToStringData(): array
+    {
+        return [
+            'basic' => [
+                'self',
+                new Self_(),
+            ],
+            'with generic' => [
+                'self<\\phpDocumentor\\FirstClass, \\phpDocumentor\\SecondClass, \\phpDocumentor\\ThirdClass>',
+                new Self_(
+                    new Object_(new Fqsen('\\phpDocumentor\\FirstClass')),
+                    new Object_(new Fqsen('\\phpDocumentor\\SecondClass')),
+                    new Object_(new Fqsen('\\phpDocumentor\\ThirdClass')),
+                ),
+            ],
+        ];
+    }
+}

--- a/tests/unit/Types/StaticTest.php
+++ b/tests/unit/Types/StaticTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace phpDocumentor\Reflection\Types;
 
 use phpDocumentor\Reflection\Fqsen;
-use phpDocumentor\Reflection\Types\Object_;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/unit/Types/StaticTest.php
+++ b/tests/unit/Types/StaticTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace phpDocumentor\Reflection\Types;
+
+use phpDocumentor\Reflection\Fqsen;
+use phpDocumentor\Reflection\Types\Object_;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @coversDefaultClass \phpDocumentor\Reflection\Types\Static_
+ */
+class StaticTest extends TestCase
+{
+    /**
+     * @covers ::getGenericTypes
+     */
+    public function testCreate(): void
+    {
+        $genericTypes = [
+            new Object_(new Fqsen('\\phpDocumentor\\FirstClass')),
+            new Object_(new Fqsen('\\phpDocumentor\\SecondClass')),
+            new Object_(new Fqsen('\\phpDocumentor\\ThirdClass')),
+        ];
+
+        $type = new Static_(...$genericTypes);
+
+        $this->assertSame($genericTypes, $type->getGenericTypes());
+    }
+
+    /**
+     * @dataProvider provideToStringData
+     * @covers ::__toString
+     */
+    public function testToString(string $expectedResult, Static_ $type): void
+    {
+        $this->assertSame($expectedResult, (string) $type);
+    }
+
+    /**
+     * @return array<string, array{string, Static_}>
+     */
+    public static function provideToStringData(): array
+    {
+        return [
+            'basic' => [
+                'static',
+                new Static_(),
+            ],
+            'with generic' => [
+                'static<\\phpDocumentor\\FirstClass, \\phpDocumentor\\SecondClass, \\phpDocumentor\\ThirdClass>',
+                new Static_(
+                    new Object_(new Fqsen('\\phpDocumentor\\FirstClass')),
+                    new Object_(new Fqsen('\\phpDocumentor\\SecondClass')),
+                    new Object_(new Fqsen('\\phpDocumentor\\ThirdClass')),
+                ),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Currently, types such as `static<SomeClass>` and `self<SomeClass>` cause exceptions. It would be great to add support for generics in `Static_` and `Self_`