### PR TITLE
Add `AbstractList::getOriginalKeyType()` method

### DIFF
--- a/src/Types/AbstractList.php
+++ b/src/Types/AbstractList.php
@@ -45,6 +45,11 @@ abstract class AbstractList implements Type
         $this->keyType        = $keyType;
     }
 
+    public function getOriginalKeyType(): ?Type
+    {
+        return $this->keyType;
+    }
+
     /**
      * Returns the type for the keys of this array.
      */


### PR DESCRIPTION
It would be great to add this method. With it, we can determine whether the type for the key is explicitly specified. Currently, this is not possible in `Collection`.