### PR TITLE
Add support for `non-empty-array` with generics

### DIFF
--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -393,7 +393,9 @@ final class TypeResolver
                 return $this->createArray($type->genericTypes, $context);
 
             case 'non-empty-array':
-                return new NonEmptyArray(...array_reverse($this->createTypesByTypeNodes($type->genericTypes, $context)));
+                return new NonEmptyArray(
+                    ...array_reverse($this->createTypesByTypeNodes($type->genericTypes, $context))
+                );
 
             case 'class-string':
                 $subType = $this->createType($type->genericTypes[0], $context);

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -393,9 +393,8 @@ final class TypeResolver
                 return $this->createArray($type->genericTypes, $context);
 
             case 'non-empty-array':
-                return new NonEmptyArray(
-                    ...array_reverse($this->createTypesByTypeNodes($type->genericTypes, $context))
-                );
+                $genericTypes = array_reverse($this->createTypesByTypeNodes($type->genericTypes, $context));
+                return new NonEmptyArray(...$genericTypes);
 
             case 'class-string':
                 $subType = $this->createType($type->genericTypes[0], $context);

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -392,6 +392,9 @@ final class TypeResolver
             case 'array':
                 return $this->createArray($type->genericTypes, $context);
 
+            case 'non-empty-array':
+                return new NonEmptyArray(...array_reverse($this->createTypesByTypeNodes($type->genericTypes, $context)));
+
             case 'class-string':
                 $subType = $this->createType($type->genericTypes[0], $context);
                 if (!$subType instanceof Object_ || $subType->getFqsen() === null) {

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -394,6 +394,7 @@ final class TypeResolver
 
             case 'non-empty-array':
                 $genericTypes = array_reverse($this->createTypesByTypeNodes($type->genericTypes, $context));
+
                 return new NonEmptyArray(...$genericTypes);
 
             case 'class-string':

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -1082,6 +1082,29 @@ class TypeResolverTest extends TestCase
                 ),
             ],
             [
+                'non-empty-array<string|int>',
+                new NonEmptyArray(
+                    new Compound(
+                        [
+                            new String_(),
+                            new Integer(),
+                        ]
+                    )
+                ),
+            ],
+            [
+                'non-empty-array<string|int, Foo\\Bar>',
+                new NonEmptyArray(
+                    new Object_(new Fqsen('\\phpDocumentor\\Foo\\Bar')),
+                    new Compound(
+                        [
+                            new String_(),
+                            new Integer(),
+                        ]
+                    )
+                ),
+            ],
+            [
                 'Collection<array-key, int>[]',
                 new Array_(
                     new Collection(
@@ -1106,6 +1129,10 @@ class TypeResolverTest extends TestCase
             [
                 'List<Foo>',
                 new List_(new Object_(new Fqsen('\\phpDocumentor\\Foo'))),
+            ],
+            [
+                'non-empty-list<Foo>',
+                new NonEmptyList(new Object_(new Fqsen('\\phpDocumentor\\Foo'))),
             ],
             [
                 'int<1, 100>',


### PR DESCRIPTION
Now this error occurs. It would be great to support types of the form `non-empty-array<keyType, valueType>`.

<img width="1445" height="88" alt="image" src="https://github.com/user-attachments/assets/280caf29-afe6-4816-9166-ecc4696bf328" />
