### PR TITLE
Fix the conversion of lists to strings

### DIFF
--- a/src/PseudoTypes/List_.php
+++ b/src/PseudoTypes/List_.php
@@ -17,7 +17,6 @@ use phpDocumentor\Reflection\PseudoType;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Integer;
-use phpDocumentor\Reflection\Types\Mixed_;
 
 /**
  * Value Object representing the type 'list'.

--- a/src/PseudoTypes/List_.php
+++ b/src/PseudoTypes/List_.php
@@ -41,7 +41,7 @@ final class List_ extends Array_ implements PseudoType
      */
     public function __toString(): string
     {
-        if ($this->valueType instanceof Mixed_) {
+        if ($this->valueType === null) {
             return 'list';
         }
 

--- a/src/PseudoTypes/NonEmptyArray.php
+++ b/src/PseudoTypes/NonEmptyArray.php
@@ -16,7 +16,6 @@ namespace phpDocumentor\Reflection\PseudoTypes;
 use phpDocumentor\Reflection\PseudoType;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Array_;
-use phpDocumentor\Reflection\Types\Mixed_;
 
 /**
  * Value Object representing the type 'non-empty-array'.

--- a/src/PseudoTypes/NonEmptyArray.php
+++ b/src/PseudoTypes/NonEmptyArray.php
@@ -35,12 +35,12 @@ final class NonEmptyArray extends Array_ implements PseudoType
      */
     public function __toString(): string
     {
-        if ($this->keyType) {
-            return 'non-empty-array<' . $this->keyType . ',' . $this->valueType . '>';
-        }
-
         if ($this->valueType === null) {
             return 'non-empty-array';
+        }
+
+        if ($this->keyType) {
+            return 'non-empty-array<' . $this->keyType . ',' . $this->valueType . '>';
         }
 
         return 'non-empty-array<' . $this->valueType . '>';

--- a/src/PseudoTypes/NonEmptyArray.php
+++ b/src/PseudoTypes/NonEmptyArray.php
@@ -39,7 +39,7 @@ final class NonEmptyArray extends Array_ implements PseudoType
             return 'non-empty-array<' . $this->keyType . ',' . $this->valueType . '>';
         }
 
-        if ($this->valueType instanceof Mixed_) {
+        if ($this->valueType === null) {
             return 'non-empty-array';
         }
 

--- a/src/PseudoTypes/NonEmptyList.php
+++ b/src/PseudoTypes/NonEmptyList.php
@@ -41,7 +41,7 @@ final class NonEmptyList extends Array_ implements PseudoType
      */
     public function __toString(): string
     {
-        if ($this->valueType instanceof Mixed_) {
+        if ($this->valueType === null) {
             return 'non-empty-list';
         }
 

--- a/src/PseudoTypes/NonEmptyList.php
+++ b/src/PseudoTypes/NonEmptyList.php
@@ -17,7 +17,6 @@ use phpDocumentor\Reflection\PseudoType;
 use phpDocumentor\Reflection\Type;
 use phpDocumentor\Reflection\Types\Array_;
 use phpDocumentor\Reflection\Types\Integer;
-use phpDocumentor\Reflection\Types\Mixed_;
 
 /**
  * Value Object representing the type 'non-empty-list'.

--- a/src/Types/AbstractList.php
+++ b/src/Types/AbstractList.php
@@ -22,7 +22,7 @@ use phpDocumentor\Reflection\Type;
  */
 abstract class AbstractList implements Type
 {
-    /** @var Type */
+    /** @var Type|null */
     protected $valueType;
 
     /** @var Type|null */
@@ -31,15 +31,15 @@ abstract class AbstractList implements Type
     /** @var Type */
     protected $defaultKeyType;
 
+    /** @var Type */
+    protected $defaultValueType;
+
     /**
      * Initializes this representation of an array with the given Type.
      */
     public function __construct(?Type $valueType = null, ?Type $keyType = null)
     {
-        if ($valueType === null) {
-            $valueType = new Mixed_();
-        }
-
+        $this->defaultValueType = new Mixed_();
         $this->valueType      = $valueType;
         $this->defaultKeyType = new Compound([new String_(), new Integer()]);
         $this->keyType        = $keyType;
@@ -48,6 +48,11 @@ abstract class AbstractList implements Type
     public function getOriginalKeyType(): ?Type
     {
         return $this->keyType;
+    }
+
+    public function getOriginalValueType(): ?Type
+    {
+        return $this->valueType;
     }
 
     /**
@@ -63,7 +68,7 @@ abstract class AbstractList implements Type
      */
     public function getValueType(): Type
     {
-        return $this->valueType;
+        return $this->valueType ?? $this->defaultValueType;
     }
 
     /**
@@ -75,7 +80,7 @@ abstract class AbstractList implements Type
             return 'array<' . $this->keyType . ',' . $this->valueType . '>';
         }
 
-        if ($this->valueType instanceof Mixed_) {
+        if ($this->valueType === null) {
             return 'array';
         }
 

--- a/src/Types/AbstractList.php
+++ b/src/Types/AbstractList.php
@@ -76,12 +76,12 @@ abstract class AbstractList implements Type
      */
     public function __toString(): string
     {
-        if ($this->keyType) {
-            return 'array<' . $this->keyType . ',' . $this->valueType . '>';
-        }
-
         if ($this->valueType === null) {
             return 'array';
+        }
+
+        if ($this->keyType) {
+            return 'array<' . $this->keyType . ',' . $this->valueType . '>';
         }
 
         if ($this->valueType instanceof Compound) {

--- a/src/Types/Collection.php
+++ b/src/Types/Collection.php
@@ -58,9 +58,7 @@ final class Collection extends AbstractList
     public function __toString(): string
     {
         $objectType = (string) ($this->fqsen ?? 'object');
-
-        /** @var string $valueType */
-        $valueType = $this->valueType;
+        $valueType = $this->getValueType();
 
         if ($this->keyType === null) {
             return $objectType . '<' . $valueType . '>';

--- a/src/Types/Collection.php
+++ b/src/Types/Collection.php
@@ -59,10 +59,13 @@ final class Collection extends AbstractList
     {
         $objectType = (string) ($this->fqsen ?? 'object');
 
+        /** @var string */
+        $valueType = $this->valueType;
+
         if ($this->keyType === null) {
-            return $objectType . '<' . $this->valueType . '>';
+            return $objectType . '<' . $valueType . '>';
         }
 
-        return $objectType . '<' . $this->keyType . ',' . $this->valueType . '>';
+        return $objectType . '<' . $this->keyType . ',' . $valueType . '>';
     }
 }

--- a/src/Types/Collection.php
+++ b/src/Types/Collection.php
@@ -59,7 +59,7 @@ final class Collection extends AbstractList
     {
         $objectType = (string) ($this->fqsen ?? 'object');
 
-        /** @var string */
+        /** @var string $valueType */
         $valueType = $this->valueType;
 
         if ($this->keyType === null) {

--- a/src/Types/Iterable_.php
+++ b/src/Types/Iterable_.php
@@ -29,7 +29,7 @@ final class Iterable_ extends AbstractList
             return 'iterable<' . $this->keyType . ',' . $this->valueType . '>';
         }
 
-        if ($this->valueType instanceof Mixed_) {
+        if ($this->valueType === null) {
             return 'iterable';
         }
 

--- a/src/Types/Iterable_.php
+++ b/src/Types/Iterable_.php
@@ -25,12 +25,12 @@ final class Iterable_ extends AbstractList
      */
     public function __toString(): string
     {
-        if ($this->keyType) {
-            return 'iterable<' . $this->keyType . ',' . $this->valueType . '>';
-        }
-
         if ($this->valueType === null) {
             return 'iterable';
+        }
+
+        if ($this->keyType) {
+            return 'iterable<' . $this->keyType . ',' . $this->valueType . '>';
         }
 
         return 'iterable<' . $this->valueType . '>';

--- a/tests/unit/PseudoTypes/ListTest.php
+++ b/tests/unit/PseudoTypes/ListTest.php
@@ -40,7 +40,7 @@ class ListTest extends TestCase
     {
         return [
             'simple list' => [new List_(), 'list'],
-            'list of mixed' => [new List_(new Mixed_()), 'list'],
+            'list of mixed' => [new List_(new Mixed_()), 'list<mixed>'],
             'list of single type' => [new List_(new String_()), 'list<string>'],
             'list of compound type' => [new List_(new Compound([new Integer(), new String_()])), 'list<int|string>'],
         ];

--- a/tests/unit/PseudoTypes/NonEmptyArrayTest.php
+++ b/tests/unit/PseudoTypes/NonEmptyArrayTest.php
@@ -40,7 +40,7 @@ class NonEmptyArrayTest extends TestCase
     {
         return [
             'simple non-empty-array' => [new NonEmptyArray(), 'non-empty-array'],
-            'non-empty-array of mixed' => [new NonEmptyArray(new Mixed_()), 'non-empty-array'],
+            'non-empty-array of mixed' => [new NonEmptyArray(new Mixed_()), 'non-empty-array<mixed>'],
             'non-empty-array of single type' => [new NonEmptyArray(new String_()), 'non-empty-array<string>'],
             'non-empty-array of compound type' =>
                 [

--- a/tests/unit/PseudoTypes/NonEmptyListTest.php
+++ b/tests/unit/PseudoTypes/NonEmptyListTest.php
@@ -40,7 +40,7 @@ class NonEmptyListTest extends TestCase
     {
         return [
             'simple non-empty-list' => [new NonEmptyList(), 'non-empty-list'],
-            'non-empty-list of mixed' => [new NonEmptyList(new Mixed_()), 'non-empty-list'],
+            'non-empty-list of mixed' => [new NonEmptyList(new Mixed_()), 'non-empty-list<mixed>'],
             'non-empty-list of single type' => [new NonEmptyList(new String_()), 'non-empty-list<string>'],
             'non-empty-list of compound type' =>
                 [new NonEmptyList(new Compound([new Integer(), new String_()])), 'non-empty-list<int|string>'],

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -983,9 +983,19 @@ class TypeResolverTest extends TestCase
                 ]),
             ],
             [
+                'array',
+                new Array_(),
+            ],
+            [
                 'string[]',
                 new Array_(
                     new String_()
+                ),
+            ],
+            [
+                'mixed[]',
+                new Array_(
+                    new Mixed_()
                 ),
             ],
             [
@@ -1177,6 +1187,22 @@ class TypeResolverTest extends TestCase
                     new Object_(new Fqsen('\\phpDocumentor\\SecondClass')),
                     new Object_(new Fqsen('\\phpDocumentor\\ThirdClass')),
                 ),
+            ],
+            [
+                'array<mixed>',
+                new Array_(new Mixed_()),
+            ],
+            [
+                'iterable<mixed>',
+                new Iterable_(new Mixed_()),
+            ],
+            [
+                'non-empty-array<mixed>',
+                new NonEmptyArray(new Mixed_()),
+            ],
+            [
+                'non-empty-list<mixed>',
+                new NonEmptyList(new Mixed_()),
             ],
         ];
     }

--- a/tests/unit/Types/ArrayTest.php
+++ b/tests/unit/Types/ArrayTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace phpDocumentor\Reflection\Types;
 
+use phpDocumentor\Reflection\Fqsen;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -20,6 +21,46 @@ use PHPUnit\Framework\TestCase;
  */
 class ArrayTest extends TestCase
 {
+    /**
+     * @covers ::getOriginalKeyType
+     * @covers ::getOriginalValueType
+     * @covers ::getKeyType
+     * @covers ::getValueType
+     */
+    public function testCreateWithoutParams(): void
+    {
+        $type = new Array_();
+
+        $this->assertNull($type->getOriginalKeyType());
+        $this->assertNull($type->getOriginalValueType());
+        $this->assertEquals(new Compound([new String_(), new Integer()]), $type->getKeyType());
+        $this->assertEquals(new Mixed_(), $type->getValueType());
+    }
+
+    /**
+     * @covers ::getOriginalKeyType
+     * @covers ::getOriginalValueType
+     * @covers ::getKeyType
+     * @covers ::getValueType
+     */
+    public function testCreateWithParams(): void
+    {
+        $valueType = new Object_(new Fqsen('\\phpDocumentor\\Foo\\Bar'));
+        $keyType = new Compound(
+            [
+                new String_(),
+                new Integer(),
+            ]
+        );
+
+        $type = new Array_($valueType, $keyType);
+
+        $this->assertSame($keyType, $type->getOriginalKeyType());
+        $this->assertSame($valueType, $type->getOriginalValueType());
+        $this->assertSame($keyType, $type->getKeyType());
+        $this->assertSame($valueType, $type->getValueType());
+    }
+
     /**
      * @dataProvider provideArrays
      * @covers ::__toString
@@ -36,7 +77,7 @@ class ArrayTest extends TestCase
     {
         return [
             'simple array' => [new Array_(), 'array'],
-            'array of mixed' => [new Array_(new Mixed_()), 'array'],
+            'array of mixed' => [new Array_(new Mixed_()), 'mixed[]'],
             'array of single type' => [new Array_(new String_()), 'string[]'],
             'array of compound type' => [new Array_(new Compound([new Integer(), new String_()])), '(int|string)[]'],
             'array with key type' => [new Array_(new String_(), new Integer()), 'array<int,string>'],

--- a/tests/unit/Types/IterableTest.php
+++ b/tests/unit/Types/IterableTest.php
@@ -36,7 +36,7 @@ class IterableTest extends TestCase
     {
         return [
             'simple iterable' => [new Iterable_(), 'iterable'],
-            'iterable of mixed' => [new Iterable_(new Mixed_()), 'iterable'],
+            'iterable of mixed' => [new Iterable_(new Mixed_()), 'iterable<mixed>'],
             'iterable of single type' => [new Iterable_(new String_()), 'iterable<string>'],
             'iterable of compound type' => [
                 new Iterable_(new Compound([new Integer(), new String_()])),


### PR DESCRIPTION
This topic has already been discussed here: https://github.com/phpDocumentor/TypeResolver/pull/48

I believe that we need to slightly modify the logic for converting lists to strings.

For example, `mixed[]` is not the same as `array`. If we explicitly write `mixed`, it means that any value can be included. If we simply use `array`, it means that we have not explicitly specified what can be included in the array.

Static analyzers in particular distinguish between these cases. I suggest that we also distinguish between these cases here.