### PR TITLE
Fix PHPUnit coverage report generation

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php"
-    colors="true" verbose="true" convertDeprecationsToExceptions="false"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit
+    bootstrap="vendor/autoload.php"
+    colors="true"
+    verbose="true"
+    convertDeprecationsToExceptions="false"
+>
     <coverage>
         <include>
             <directory suffix=".php">src</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,28 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-
-<phpunit
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    verbose="true"
-    convertDeprecationsToExceptions="false"
-    forceCoversAnnotation="true"
->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php"
+    colors="true" verbose="true" convertDeprecationsToExceptions="false"
+    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <report>
+            <clover outputFile="build/logs/clover.xml" />
+            <html outputDirectory="build/coverage" lowUpperBound="35" highLowerBound="70" />
+        </report>
+    </coverage>
     <testsuites>
         <testsuite name="unit">
             <directory>./tests/unit/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
     <logging>
-        <log type="coverage-html"
-            target="build/coverage"
-            lowUpperBound="35"
-            highLowerBound="70" />
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="junit" target="build/logs/junit.xml"/>
+        <junit outputFile="build/logs/junit.xml" />
     </logging>
 </phpunit>

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -34,7 +34,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\PseudoTypes\Generic
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingCollection(): void
     {
@@ -53,7 +52,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\PseudoTypes\Generic
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingCollectionWithKeyType(): void
     {
@@ -77,7 +75,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingArrayCollection(): void
     {
@@ -100,7 +97,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingArrayCollectionWithKey(): void
     {
@@ -147,7 +143,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\PseudoTypes\Generic
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingCollectionOfCollection(): void
     {
@@ -216,7 +211,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingCollectionAsArray(): void
     {
@@ -238,7 +232,6 @@ class CollectionResolverTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingList(): void
     {
@@ -260,7 +253,6 @@ class CollectionResolverTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingNonEmptyList(): void
     {
@@ -282,7 +274,6 @@ class CollectionResolverTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Nullable
-     *
      */
     public function testResolvingNullableArray(): void
     {

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -119,7 +119,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
-
      */
     public function testResolvingArrayCollectionWithKeyAndWhitespace(): void
     {

--- a/tests/unit/CollectionResolverTest.php
+++ b/tests/unit/CollectionResolverTest.php
@@ -27,9 +27,6 @@ use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\TypeResolver
- */
 class CollectionResolverTest extends TestCase
 {
     /**
@@ -38,9 +35,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\PseudoTypes\Generic
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::resolve
-     * @covers ::createType
-     * @covers ::__construct
      */
     public function testResolvingCollection(): void
     {
@@ -60,9 +54,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\PseudoTypes\Generic
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingCollectionWithKeyType(): void
     {
@@ -87,9 +78,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingArrayCollection(): void
     {
@@ -113,9 +101,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingArrayCollectionWithKey(): void
     {
@@ -139,9 +124,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
 
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingArrayCollectionWithKeyAndWhitespace(): void
     {
@@ -166,9 +148,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\PseudoTypes\Generic
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingCollectionOfCollection(): void
     {
@@ -194,11 +173,6 @@ class CollectionResolverTest extends TestCase
         $this->assertEquals(new Object_(new Fqsen('\\DateTime')), $nestedGenericTypes[0]);
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
-     */
     public function testGoodArrayCollectionKey(): void
     {
         $fixture = new TypeResolver();
@@ -214,11 +188,6 @@ class CollectionResolverTest extends TestCase
         $this->assertSame('array<class-string,string>', (string) $resolvedType);
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
-     */
     public function testMissingStartCollection(): void
     {
         $this->expectException(RuntimeException::class);
@@ -227,11 +196,6 @@ class CollectionResolverTest extends TestCase
         $fixture->resolve('<string>', new Context(''));
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
-     */
     public function testMissingEndCollection(): void
     {
         $this->expectException(RuntimeException::class);
@@ -240,11 +204,6 @@ class CollectionResolverTest extends TestCase
         $fixture->resolve('ArrayObject<object|string', new Context(''));
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
-     */
     public function testBadCollectionClass(): void
     {
         $this->expectException(RuntimeException::class);
@@ -258,9 +217,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingCollectionAsArray(): void
     {
@@ -283,9 +239,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingList(): void
     {
@@ -308,9 +261,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingNonEmptyList(): void
     {
@@ -333,9 +283,6 @@ class CollectionResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Nullable
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingNullableArray(): void
     {

--- a/tests/unit/FqsenResolverTest.php
+++ b/tests/unit/FqsenResolverTest.php
@@ -17,14 +17,8 @@ use InvalidArgumentException;
 use phpDocumentor\Reflection\Types\Context;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\FqsenResolver
- */
 final class FqsenResolverTest extends TestCase
 {
-    /**
-     * @covers ::resolve
-     */
     public function testResolveFqsen(): void
     {
         $fqsenResolver = new FqsenResolver();
@@ -35,9 +29,6 @@ final class FqsenResolverTest extends TestCase
         static::assertSame('\DocBlock', (string) $result);
     }
 
-    /**
-     * @covers ::resolve
-     */
     public function testResolveFqsenWithEmoji(): void
     {
         $fqsenResolver = new FqsenResolver();
@@ -48,9 +39,6 @@ final class FqsenResolverTest extends TestCase
         static::assertSame('\My😁DocBlock', (string) $result);
     }
 
-    /**
-     * @covers ::resolve
-     */
     public function testResolveWithoutContext(): void
     {
         $fqsenResolver = new FqsenResolver();
@@ -59,9 +47,6 @@ final class FqsenResolverTest extends TestCase
         static::assertSame('\DocBlock', (string) $result);
     }
 
-    /**
-     * @covers ::resolve
-     */
     public function testResolveFromAlias(): void
     {
         $fqsenResolver = new FqsenResolver();
@@ -72,9 +57,6 @@ final class FqsenResolverTest extends TestCase
         static::assertSame('\some\other\ns', (string) $result);
     }
 
-    /**
-     * @covers ::resolve
-     */
     public function testResolveFromPartialAlias(): void
     {
         $fqsenResolver = new FqsenResolver();
@@ -85,9 +67,6 @@ final class FqsenResolverTest extends TestCase
         static::assertSame('\some\other\ns', (string) $result);
     }
 
-    /**
-     * @covers ::resolve
-     */
     public function testResolveThrowsExceptionWhenGarbageInputIsPassed(): void
     {
         $this->expectException(InvalidArgumentException::class);

--- a/tests/unit/IntegerRangeResolverTest.php
+++ b/tests/unit/IntegerRangeResolverTest.php
@@ -24,7 +24,6 @@ class IntegerRangeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingIntRange(): void
     {
@@ -46,7 +45,6 @@ class IntegerRangeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingIntRangeWithKeywords(): void
     {
@@ -68,7 +66,6 @@ class IntegerRangeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingIntRangeErrorMissingMaxValue(): void
     {
@@ -83,7 +80,6 @@ class IntegerRangeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingIntRangeErrorMisingMinValue(): void
     {
@@ -98,7 +94,6 @@ class IntegerRangeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingIntRangeErrorMisingComma(): void
     {
@@ -113,7 +108,6 @@ class IntegerRangeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingIntRangeErrorMissingEnd(): void
     {

--- a/tests/unit/IntegerRangeResolverTest.php
+++ b/tests/unit/IntegerRangeResolverTest.php
@@ -18,9 +18,6 @@ use phpDocumentor\Reflection\Types\Context;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\TypeResolver
- */
 class IntegerRangeResolverTest extends TestCase
 {
     /**
@@ -28,9 +25,6 @@ class IntegerRangeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingIntRange(): void
     {
@@ -53,9 +47,6 @@ class IntegerRangeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingIntRangeWithKeywords(): void
     {
@@ -78,9 +69,6 @@ class IntegerRangeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingIntRangeErrorMissingMaxValue(): void
     {
@@ -96,9 +84,6 @@ class IntegerRangeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingIntRangeErrorMisingMinValue(): void
     {
@@ -114,9 +99,6 @@ class IntegerRangeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingIntRangeErrorMisingComma(): void
     {
@@ -132,9 +114,6 @@ class IntegerRangeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingIntRangeErrorMissingEnd(): void
     {

--- a/tests/unit/NumericResolverTest.php
+++ b/tests/unit/NumericResolverTest.php
@@ -20,9 +20,6 @@ use phpDocumentor\Reflection\Types\Context;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\TypeResolver
- */
 class NumericResolverTest extends TestCase
 {
     /**
@@ -30,7 +27,6 @@ class NumericResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
      */
     public function testResolvingIntRange(): void
     {

--- a/tests/unit/NumericResolverTest.php
+++ b/tests/unit/NumericResolverTest.php
@@ -26,7 +26,6 @@ class NumericResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Compound
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingIntRange(): void
     {

--- a/tests/unit/PseudoTypes/ArrayKeyTest.php
+++ b/tests/unit/PseudoTypes/ArrayKeyTest.php
@@ -26,7 +26,6 @@ final class ArrayKeyTest extends TestCase
 
     /**
      * @uses \phpDocumentor\Reflection\PseudoTypes\ArrayKey::__construct
-     *
      */
     public function testArrayKeyCanBeIterated(): void
     {

--- a/tests/unit/PseudoTypes/ArrayKeyTest.php
+++ b/tests/unit/PseudoTypes/ArrayKeyTest.php
@@ -17,15 +17,8 @@ use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\ArrayKey
- */
 final class ArrayKeyTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::__toString
-     */
     public function testArrayKeyCanBeConstructedAndStringifiedCorrectly(): void
     {
         $this->assertSame('array-key', (string) (new ArrayKey()));
@@ -34,7 +27,6 @@ final class ArrayKeyTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\PseudoTypes\ArrayKey::__construct
      *
-     * @covers ::getIterator
      */
     public function testArrayKeyCanBeIterated(): void
     {

--- a/tests/unit/PseudoTypes/ArrayShapeTest.php
+++ b/tests/unit/PseudoTypes/ArrayShapeTest.php
@@ -6,14 +6,8 @@ namespace phpDocumentor\Reflection\PseudoTypes;
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\ArrayShape
- */
 class ArrayShapeTest extends TestCase
 {
-    /**
-     * @covers ::getItems
-     */
     public function testExposeItems(): void
     {
         $item1 = new ArrayShapeItem('foo', new True_(), false);
@@ -26,7 +20,6 @@ class ArrayShapeTest extends TestCase
 
     /**
      * @dataProvider provideToStringData
-     * @covers ::__toString
      */
     public function testToString(string $expectedResult, ArrayShape $arrayShape): void
     {

--- a/tests/unit/PseudoTypes/ClassStringTest.php
+++ b/tests/unit/PseudoTypes/ClassStringTest.php
@@ -18,14 +18,10 @@ use phpDocumentor\Reflection\Types\Compound;
 use phpDocumentor\Reflection\Types\Object_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\ClassString
- */
 class ClassStringTest extends TestCase
 {
     /**
      * @dataProvider provideClassStrings
-     * @covers ::__toString
      */
     public function testClassStringStringifyCorrectly(ClassString $type, string $expectedString): void
     {

--- a/tests/unit/PseudoTypes/ConditionalForParameterTest.php
+++ b/tests/unit/PseudoTypes/ConditionalForParameterTest.php
@@ -9,18 +9,8 @@ use phpDocumentor\Reflection\Types\Integer;
 use phpDocumentor\Reflection\Types\Static_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\ConditionalForParameter
- */
 class ConditionalForParameterTest extends TestCase
 {
-    /**
-     * @covers ::isNegated
-     * @covers ::getParameterName
-     * @covers ::getTargetType
-     * @covers ::getIf
-     * @covers ::getElse
-     */
     public function testCreate(): void
     {
         $parameterName = 'some';
@@ -38,7 +28,6 @@ class ConditionalForParameterTest extends TestCase
 
     /**
      * @dataProvider provideToStringData
-     * @covers ::__toString
      */
     public function testToString(string $expectedResult, ConditionalForParameter $type): void
     {

--- a/tests/unit/PseudoTypes/ConditionalTest.php
+++ b/tests/unit/PseudoTypes/ConditionalTest.php
@@ -11,18 +11,8 @@ use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\Static_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\Conditional
- */
 class ConditionalTest extends TestCase
 {
-    /**
-     * @covers ::isNegated
-     * @covers ::getSubjectType
-     * @covers ::getTargetType
-     * @covers ::getIf
-     * @covers ::getElse
-     */
     public function testCreate(): void
     {
         $subjectType = new Object_(new Fqsen('\\phpDocumentor\\T'));
@@ -40,7 +30,6 @@ class ConditionalTest extends TestCase
 
     /**
      * @dataProvider provideToStringData
-     * @covers ::__toString
      */
     public function testToString(string $expectedResult, Conditional $type): void
     {

--- a/tests/unit/PseudoTypes/FalseTest.php
+++ b/tests/unit/PseudoTypes/FalseTest.php
@@ -16,14 +16,8 @@ namespace phpDocumentor\Reflection\PseudoTypes;
 use phpDocumentor\Reflection\Types\Boolean;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\False_
- */
 final class FalseTest extends TestCase
 {
-    /**
-     * @covers ::underlyingType
-     */
     public function testExposesUnderlyingType(): void
     {
         $false = new False_();
@@ -31,9 +25,6 @@ final class FalseTest extends TestCase
         $this->assertInstanceOf(Boolean::class, $false->underlyingType());
     }
 
-    /**
-     * @covers ::__toString
-     */
     public function testFalseStringifyCorrectly(): void
     {
         $false = new False_();

--- a/tests/unit/PseudoTypes/GenericTest.php
+++ b/tests/unit/PseudoTypes/GenericTest.php
@@ -11,15 +11,8 @@ use phpDocumentor\Reflection\Types\Object_;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\Generic
- */
 class GenericTest extends TestCase
 {
-    /**
-     * @covers ::getFqsen
-     * @covers ::getTypes
-     */
     public function testCreate(): void
     {
         $fqsen = new Fqsen('\\Foo\\Bar');
@@ -32,7 +25,6 @@ class GenericTest extends TestCase
 
     /**
      * @dataProvider provideToStringData
-     * @covers ::__toString
      */
     public function testToString(string $expectedResult, Generic $type): void
     {

--- a/tests/unit/PseudoTypes/IntMaskOfTest.php
+++ b/tests/unit/PseudoTypes/IntMaskOfTest.php
@@ -7,14 +7,8 @@ namespace phpDocumentor\Reflection\PseudoTypes;
 use phpDocumentor\Reflection\Types\Compound;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\IntMaskOf
- */
 class IntMaskOfTest extends TestCase
 {
-    /**
-     * @covers ::getType
-     */
     public function testCreate(): void
     {
         $childType = new Compound([new IntegerValue(1), new IntegerValue(5), new IntegerValue(10)]);
@@ -23,9 +17,6 @@ class IntMaskOfTest extends TestCase
         $this->assertSame($childType, $type->getType());
     }
 
-    /**
-     * @covers ::__toString
-     */
     public function testToString(): void
     {
         $type = new IntMaskOf(new Compound([new IntegerValue(1), new IntegerValue(5), new IntegerValue(10)]));

--- a/tests/unit/PseudoTypes/IntMaskTest.php
+++ b/tests/unit/PseudoTypes/IntMaskTest.php
@@ -6,14 +6,8 @@ namespace phpDocumentor\Reflection\PseudoTypes;
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\IntMask
- */
 class IntMaskTest extends TestCase
 {
-    /**
-     * @covers ::getTypes
-     */
     public function testCreate(): void
     {
         $childTypes = [new IntegerValue(1), new IntegerValue(5), new IntegerValue(10)];
@@ -22,9 +16,6 @@ class IntMaskTest extends TestCase
         $this->assertSame($childTypes, $type->getTypes());
     }
 
-    /**
-     * @covers ::__toString
-     */
     public function testToString(): void
     {
         $type = new IntMask(new IntegerValue(1), new IntegerValue(510), new IntegerValue(6000));

--- a/tests/unit/PseudoTypes/IntRangeTest.php
+++ b/tests/unit/PseudoTypes/IntRangeTest.php
@@ -15,14 +15,10 @@ namespace phpDocumentor\Reflection\PseudoTypes;
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\List_
- */
 class IntRangeTest extends TestCase
 {
     /**
      * @dataProvider provideArrays
-     * @covers ::__toString
      */
     public function testArrayStringifyCorrectly(IntegerRange $array, string $expectedString): void
     {

--- a/tests/unit/PseudoTypes/InterfaceStringTest.php
+++ b/tests/unit/PseudoTypes/InterfaceStringTest.php
@@ -18,14 +18,10 @@ use phpDocumentor\Reflection\Types\Compound;
 use phpDocumentor\Reflection\Types\Object_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\InterfaceString
- */
 class InterfaceStringTest extends TestCase
 {
     /**
      * @dataProvider provideInterfaceStrings
-     * @covers ::__toString
      */
     public function testInterfaceStringStringifyCorrectly(InterfaceString $type, string $expectedString): void
     {

--- a/tests/unit/PseudoTypes/KeyOfTest.php
+++ b/tests/unit/PseudoTypes/KeyOfTest.php
@@ -8,14 +8,8 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Types\Object_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\KeyOf
- */
 class KeyOfTest extends TestCase
 {
-    /**
-     * @covers ::getType
-     */
     public function testCreate(): void
     {
         $childType = new ConstExpression(new Object_(new Fqsen('\\phpDocumentor\\Type')), 'ARRAY_CONST');
@@ -24,9 +18,6 @@ class KeyOfTest extends TestCase
         $this->assertSame($childType, $type->getType());
     }
 
-    /**
-     * @covers ::__toString
-     */
     public function testToString(): void
     {
         $type = new KeyOf(new ConstExpression(new Object_(new Fqsen('\\phpDocumentor\\Type')), 'ARRAY_CONST'));

--- a/tests/unit/PseudoTypes/ListTest.php
+++ b/tests/unit/PseudoTypes/ListTest.php
@@ -19,14 +19,10 @@ use phpDocumentor\Reflection\Types\Mixed_;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\List_
- */
 class ListTest extends TestCase
 {
     /**
      * @dataProvider provideArrays
-     * @covers ::__toString
      */
     public function testArrayStringifyCorrectly(List_ $array, string $expectedString): void
     {

--- a/tests/unit/PseudoTypes/NonEmptyArrayTest.php
+++ b/tests/unit/PseudoTypes/NonEmptyArrayTest.php
@@ -19,14 +19,10 @@ use phpDocumentor\Reflection\Types\Mixed_;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\NonEmptyArray
- */
 class NonEmptyArrayTest extends TestCase
 {
     /**
      * @dataProvider provideArrays
-     * @covers ::__toString
      */
     public function testArrayStringifyCorrectly(NonEmptyArray $array, string $expectedString): void
     {

--- a/tests/unit/PseudoTypes/NonEmptyListTest.php
+++ b/tests/unit/PseudoTypes/NonEmptyListTest.php
@@ -19,14 +19,10 @@ use phpDocumentor\Reflection\Types\Mixed_;
 use phpDocumentor\Reflection\Types\String_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\NonEmptyList
- */
 class NonEmptyListTest extends TestCase
 {
     /**
      * @dataProvider provideArrays
-     * @covers ::__toString
      */
     public function testArrayStringifyCorrectly(NonEmptyList $array, string $expectedString): void
     {

--- a/tests/unit/PseudoTypes/OffsetAccessTest.php
+++ b/tests/unit/PseudoTypes/OffsetAccessTest.php
@@ -8,15 +8,8 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Types\Object_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\OffsetAccess
- */
 class OffsetAccessTest extends TestCase
 {
-    /**
-     * @covers ::getType
-     * @covers ::getOffset
-     */
     public function testCreate(): void
     {
         $mainType = new Object_(new Fqsen('\\phpDocumentor\\MyArray'));
@@ -29,7 +22,6 @@ class OffsetAccessTest extends TestCase
 
     /**
      * @dataProvider provideToStringData
-     * @covers ::__toString
      */
     public function testToString(string $expectedResult, OffsetAccess $type): void
     {

--- a/tests/unit/PseudoTypes/TrueTest.php
+++ b/tests/unit/PseudoTypes/TrueTest.php
@@ -16,14 +16,8 @@ namespace phpDocumentor\Reflection\PseudoTypes;
 use phpDocumentor\Reflection\Types\Boolean;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\True_
- */
 class TrueTest extends TestCase
 {
-    /**
-     * @covers ::underlyingType
-     */
     public function testExposesUnderlyingType(): void
     {
         $true = new True_();
@@ -31,9 +25,6 @@ class TrueTest extends TestCase
         $this->assertInstanceOf(Boolean::class, $true->underlyingType());
     }
 
-    /**
-     * @covers ::__toString
-     */
     public function testTrueStringifyCorrectly(): void
     {
         $true = new True_();

--- a/tests/unit/PseudoTypes/ValueOfTest.php
+++ b/tests/unit/PseudoTypes/ValueOfTest.php
@@ -8,14 +8,8 @@ use phpDocumentor\Reflection\Fqsen;
 use phpDocumentor\Reflection\Types\Object_;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\PseudoTypes\ValueOf
- */
 class ValueOfTest extends TestCase
 {
-    /**
-     * @covers ::getType
-     */
     public function testCreate(): void
     {
         $childType = new ConstExpression(new Object_(new Fqsen('\\phpDocumentor\\Type')), 'ARRAY_CONST');
@@ -24,9 +18,6 @@ class ValueOfTest extends TestCase
         $this->assertSame($childType, $type->getType());
     }
 
-    /**
-     * @covers ::__toString
-     */
     public function testToString(): void
     {
         $type = new ValueOf(new ConstExpression(new Object_(new Fqsen('\\phpDocumentor\\Type')), 'ARRAY_CONST'));

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -83,9 +83,6 @@ use stdClass;
 
 use function get_class;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\TypeResolver
- */
 class TypeResolverTest extends TestCase
 {
     use VerifyDeprecations;
@@ -97,9 +94,6 @@ class TypeResolverTest extends TestCase
      *
      * @param class-string $expectedClass
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      *
      * @dataProvider provideKeywords
      */
@@ -118,9 +112,6 @@ class TypeResolverTest extends TestCase
      * @uses         \phpDocumentor\Reflection\Fqsen
      * @uses         \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      *
      * @dataProvider provideFqcn
      */
@@ -141,9 +132,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingRelativeQSENsBasedOnNamespace(): void
     {
@@ -162,9 +150,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingRelativeQSENsBasedOnNamespaceAlias(): void
     {
@@ -185,9 +170,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Array_
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingTypedArrays(): void
     {
@@ -206,9 +188,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Nullable
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingNullableTypes(): void
     {
@@ -226,9 +205,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Array_
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingNestedTypedArrays(): void
     {
@@ -256,9 +232,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingCompoundTypes(): void
     {
@@ -286,9 +259,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingAmpersandCompoundTypes(): void
     {
@@ -323,9 +293,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingMixedCompoundTypes(): void
     {
@@ -373,9 +340,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingCompoundTypedArrayTypes(): void
     {
@@ -404,9 +368,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingArrayExpressionObjectsTypes(): void
     {
@@ -437,9 +398,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingArrayExpressionSimpleTypes(): void
     {
@@ -473,9 +431,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingArrayOfArrayExpressionTypes(): void
     {
@@ -508,9 +463,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testReturnEmptyCompoundOnAnUnclosedArrayExpressionType(): void
     {
@@ -527,9 +479,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingArrayExpressionOrCompoundTypes(): void
     {
@@ -568,9 +517,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingIterableExpressionSimpleTypes(): void
     {
@@ -610,9 +556,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testResolvingCompoundTypesWithTwoArrays(): void
     {
@@ -638,8 +581,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver::<private>
      * @uses \phpDocumentor\Reflection\Types\Context
      *
-     * @covers ::__construct
-     * @covers ::addKeyword
      */
     public function testAddingAKeyword(): void
     {
@@ -659,8 +600,6 @@ class TypeResolverTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
      *
-     * @covers ::__construct
-     * @covers ::addKeyword
      */
     public function testAddingAKeywordFailsIfTypeClassDoesNotExist(): void
     {
@@ -672,8 +611,6 @@ class TypeResolverTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
      *
-     * @covers ::__construct
-     * @covers ::addKeyword
      */
     public function testAddingAKeywordFailsIfTypeClassDoesNotImplementTypeInterface(): void
     {
@@ -685,9 +622,6 @@ class TypeResolverTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testExceptionIsThrownIfTypeIsEmpty(): void
     {
@@ -699,9 +633,6 @@ class TypeResolverTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testInvalidArrayOperator(): void
     {
@@ -780,9 +711,6 @@ class TypeResolverTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
      *
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      */
     public function testArrayKeyValueSpecification(): void
     {
@@ -793,9 +721,6 @@ class TypeResolverTest extends TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      * @dataProvider typeProvider
      * @dataProvider genericsProvider
      * @dataProvider callableProvider
@@ -814,9 +739,6 @@ class TypeResolverTest extends TestCase
     }
 
     /**
-     * @covers ::__construct
-     * @covers ::resolve
-     * @covers ::createType
      * @dataProvider illegalLegacyFormatProvider
      * @testdox create type from $type
      */

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -94,7 +94,6 @@ class TypeResolverTest extends TestCase
      *
      * @param class-string $expectedClass
      *
-     *
      * @dataProvider provideKeywords
      */
     public function testResolvingKeywords(string $keyword, string $expectedClass): void
@@ -111,7 +110,6 @@ class TypeResolverTest extends TestCase
      * @uses         \phpDocumentor\Reflection\Types\Object_
      * @uses         \phpDocumentor\Reflection\Fqsen
      * @uses         \phpDocumentor\Reflection\FqsenResolver
-     *
      *
      * @dataProvider provideFqcn
      */

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -131,7 +131,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Object_
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
-     *
      */
     public function testResolvingRelativeQSENsBasedOnNamespace(): void
     {
@@ -149,7 +148,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Object_
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
-     *
      */
     public function testResolvingRelativeQSENsBasedOnNamespaceAlias(): void
     {
@@ -169,7 +167,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Array_
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingTypedArrays(): void
     {
@@ -187,7 +184,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Nullable
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingNullableTypes(): void
     {
@@ -204,7 +200,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Context
      * @uses \phpDocumentor\Reflection\Types\Array_
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingNestedTypedArrays(): void
     {
@@ -231,7 +226,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Object_
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
-     *
      */
     public function testResolvingCompoundTypes(): void
     {
@@ -258,7 +252,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Object_
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
-     *
      */
     public function testResolvingAmpersandCompoundTypes(): void
     {
@@ -292,7 +285,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Object_
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
-     *
      */
     public function testResolvingMixedCompoundTypes(): void
     {
@@ -339,7 +331,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Object_
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
-     *
      */
     public function testResolvingCompoundTypedArrayTypes(): void
     {
@@ -367,7 +358,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Object_
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
-     *
      */
     public function testResolvingArrayExpressionObjectsTypes(): void
     {
@@ -397,7 +387,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Object_
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
-     *
      */
     public function testResolvingArrayExpressionSimpleTypes(): void
     {
@@ -430,7 +419,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Object_
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
-     *
      */
     public function testResolvingArrayOfArrayExpressionTypes(): void
     {
@@ -462,7 +450,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Object_
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
-     *
      */
     public function testReturnEmptyCompoundOnAnUnclosedArrayExpressionType(): void
     {
@@ -478,7 +465,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Object_
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
-     *
      */
     public function testResolvingArrayExpressionOrCompoundTypes(): void
     {
@@ -516,7 +502,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Object_
      * @uses \phpDocumentor\Reflection\Fqsen
      * @uses \phpDocumentor\Reflection\FqsenResolver
-     *
      */
     public function testResolvingIterableExpressionSimpleTypes(): void
     {
@@ -555,7 +540,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Array_
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testResolvingCompoundTypesWithTwoArrays(): void
     {
@@ -580,7 +564,6 @@ class TypeResolverTest extends TestCase
      * @uses \phpDocumentor\Reflection\TypeResolver::resolve
      * @uses \phpDocumentor\Reflection\TypeResolver::<private>
      * @uses \phpDocumentor\Reflection\Types\Context
-     *
      */
     public function testAddingAKeyword(): void
     {
@@ -599,7 +582,6 @@ class TypeResolverTest extends TestCase
 
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
-     *
      */
     public function testAddingAKeywordFailsIfTypeClassDoesNotExist(): void
     {
@@ -610,7 +592,6 @@ class TypeResolverTest extends TestCase
 
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
-     *
      */
     public function testAddingAKeywordFailsIfTypeClassDoesNotImplementTypeInterface(): void
     {
@@ -621,7 +602,6 @@ class TypeResolverTest extends TestCase
 
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
-     *
      */
     public function testExceptionIsThrownIfTypeIsEmpty(): void
     {
@@ -632,7 +612,6 @@ class TypeResolverTest extends TestCase
 
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
-     *
      */
     public function testInvalidArrayOperator(): void
     {
@@ -710,7 +689,6 @@ class TypeResolverTest extends TestCase
 
     /**
      * @uses \phpDocumentor\Reflection\Types\Context
-     *
      */
     public function testArrayKeyValueSpecification(): void
     {

--- a/tests/unit/Types/ArrayTest.php
+++ b/tests/unit/Types/ArrayTest.php
@@ -16,17 +16,8 @@ namespace phpDocumentor\Reflection\Types;
 use phpDocumentor\Reflection\Fqsen;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\Types\Array_
- */
 class ArrayTest extends TestCase
 {
-    /**
-     * @covers ::getOriginalKeyType
-     * @covers ::getOriginalValueType
-     * @covers ::getKeyType
-     * @covers ::getValueType
-     */
     public function testCreateWithoutParams(): void
     {
         $type = new Array_();
@@ -37,12 +28,6 @@ class ArrayTest extends TestCase
         $this->assertEquals(new Mixed_(), $type->getValueType());
     }
 
-    /**
-     * @covers ::getOriginalKeyType
-     * @covers ::getOriginalValueType
-     * @covers ::getKeyType
-     * @covers ::getValueType
-     */
     public function testCreateWithParams(): void
     {
         $valueType = new Object_(new Fqsen('\\phpDocumentor\\Foo\\Bar'));
@@ -63,7 +48,6 @@ class ArrayTest extends TestCase
 
     /**
      * @dataProvider provideArrays
-     * @covers ::__toString
      */
     public function testArrayStringifyCorrectly(Array_ $array, string $expectedString): void
     {

--- a/tests/unit/Types/BooleanTest.php
+++ b/tests/unit/Types/BooleanTest.php
@@ -15,14 +15,8 @@ namespace phpDocumentor\Reflection\Types;
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\Types\Boolean
- */
 final class BooleanTest extends TestCase
 {
-    /**
-     * @covers ::__toString
-     */
     public function testBooleanStringifyCorrectly(): void
     {
         $type = new Boolean();

--- a/tests/unit/Types/CompoundTest.php
+++ b/tests/unit/Types/CompoundTest.php
@@ -18,14 +18,8 @@ use TypeError;
 
 use function iterator_to_array;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\Types\Compound
- */
 final class CompoundTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     */
     public function testCompoundCannotBeConstructedFromType(): void
     {
         $this->expectException(TypeError::class);
@@ -37,7 +31,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound::has
      * @uses \phpDocumentor\Reflection\Types\Integer
      *
-     * @covers ::get
      */
     public function testCompoundGetType(): void
     {
@@ -50,7 +43,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound::__construct
      * @uses \phpDocumentor\Reflection\Types\Compound::has
      *
-     * @covers ::get
      */
     public function testCompoundGetNotExistingType(): void
     {
@@ -61,7 +53,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound::__construct
      * @uses \phpDocumentor\Reflection\Types\Integer
      *
-     * @covers ::has
      */
     public function testCompoundHasIndex(): void
     {
@@ -71,7 +62,6 @@ final class CompoundTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Compound::__construct
      *
-     * @covers ::has
      */
     public function testCompoundDoesNotHasIndex(): void
     {
@@ -82,7 +72,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound::__construct
      * @uses \phpDocumentor\Reflection\Types\Integer
      *
-     * @covers ::contains
      */
     public function testCompoundContainsType(): void
     {
@@ -94,7 +83,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\String_
      *
-     * @covers ::contains
      */
     public function testCompoundDoesNotContainType(): void
     {
@@ -105,8 +93,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\Boolean
      *
-     * @covers ::__construct
-     * @covers ::__toString
      */
     public function testCompoundCanBeConstructedAndStringifiedCorrectly(): void
     {
@@ -117,8 +103,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\Boolean
      *
-     * @covers ::__construct
-     * @covers ::__toString
      */
     public function testCompoundDoesNotContainDuplicates(): void
     {
@@ -133,7 +117,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\Boolean
      *
-     * @covers ::getIterator
      */
     public function testCompoundCanBeIterated(): void
     {
@@ -148,8 +131,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\Boolean
      *
-     * @covers ::__construct
-     * @covers ::__toString
      */
     public function testCompoundIsMergedWithCompound(): void
     {
@@ -163,8 +144,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\Boolean
      *
-     * @covers ::__construct
-     * @covers ::__toString
      */
     public function testCompoundIsMergedOnMergedWithIntersection(): void
     {

--- a/tests/unit/Types/CompoundTest.php
+++ b/tests/unit/Types/CompoundTest.php
@@ -30,7 +30,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound::__construct
      * @uses \phpDocumentor\Reflection\Types\Compound::has
      * @uses \phpDocumentor\Reflection\Types\Integer
-     *
      */
     public function testCompoundGetType(): void
     {
@@ -42,7 +41,6 @@ final class CompoundTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Compound::__construct
      * @uses \phpDocumentor\Reflection\Types\Compound::has
-     *
      */
     public function testCompoundGetNotExistingType(): void
     {
@@ -52,7 +50,6 @@ final class CompoundTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Compound::__construct
      * @uses \phpDocumentor\Reflection\Types\Integer
-     *
      */
     public function testCompoundHasIndex(): void
     {
@@ -61,7 +58,6 @@ final class CompoundTest extends TestCase
 
     /**
      * @uses \phpDocumentor\Reflection\Types\Compound::__construct
-     *
      */
     public function testCompoundDoesNotHasIndex(): void
     {
@@ -71,7 +67,6 @@ final class CompoundTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Compound::__construct
      * @uses \phpDocumentor\Reflection\Types\Integer
-     *
      */
     public function testCompoundContainsType(): void
     {
@@ -82,7 +77,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound::__construct
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\String_
-     *
      */
     public function testCompoundDoesNotContainType(): void
     {
@@ -92,7 +86,6 @@ final class CompoundTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\Boolean
-     *
      */
     public function testCompoundCanBeConstructedAndStringifiedCorrectly(): void
     {
@@ -102,7 +95,6 @@ final class CompoundTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\Boolean
-     *
      */
     public function testCompoundDoesNotContainDuplicates(): void
     {
@@ -116,7 +108,6 @@ final class CompoundTest extends TestCase
      * @uses \phpDocumentor\Reflection\Types\Compound::__construct
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\Boolean
-     *
      */
     public function testCompoundCanBeIterated(): void
     {
@@ -130,7 +121,6 @@ final class CompoundTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\Boolean
-     *
      */
     public function testCompoundIsMergedWithCompound(): void
     {
@@ -143,7 +133,6 @@ final class CompoundTest extends TestCase
     /**
      * @uses \phpDocumentor\Reflection\Types\Integer
      * @uses \phpDocumentor\Reflection\Types\Boolean
-     *
      */
     public function testCompoundIsMergedOnMergedWithIntersection(): void
     {

--- a/tests/unit/Types/ContextFactoryTest.php
+++ b/tests/unit/Types/ContextFactoryTest.php
@@ -22,14 +22,9 @@ namespace phpDocumentor\Reflection\Types {
     use \ReflectionClass;
     use stdClass;
 
-    /**
-     * @coversDefaultClass \phpDocumentor\Reflection\Types\ContextFactory
-     */
     class ContextFactoryTest extends TestCase
     {
         /**
-         * @covers ::createFromReflector
-         * @covers ::createForNamespace
          * @uses phpDocumentor\Reflection\Types\Context
          */
         public function testReadsNamespaceFromClassReflection() : void
@@ -41,8 +36,6 @@ namespace phpDocumentor\Reflection\Types {
         }
 
         /**
-         * @covers ::createFromReflector
-         * @covers ::createForNamespace
          * @uses phpDocumentor\Reflection\Types\Context
          */
         public function testReadsAliasesFromClassReflection() : void
@@ -54,7 +47,6 @@ namespace phpDocumentor\Reflection\Types {
         }
 
         /**
-         * @covers ::createForNamespace
          * @uses phpDocumentor\Reflection\Types\Context
          */
         public function testReadsNamespaceFromProvidedNamespaceAndContent() : void
@@ -66,7 +58,6 @@ namespace phpDocumentor\Reflection\Types {
         }
 
         /**
-         * @covers ::createForNamespace
          * @uses phpDocumentor\Reflection\Types\Context
          */
         public function testReadsAliasesFromProvidedNamespaceAndContent() : void
@@ -78,7 +69,6 @@ namespace phpDocumentor\Reflection\Types {
         }
 
         /**
-         * @covers ::createForNamespace
          * @uses phpDocumentor\Reflection\Types\Context
          */
         public function testTraitUseIsNotDetectedAsNamespaceUse() : void
@@ -100,7 +90,6 @@ namespace phpDocumentor\Reflection\Types {
         }
 
         /**
-         * @covers ::createForNamespace
          * @uses phpDocumentor\Reflection\Types\Context
          */
         public function testAllOpeningBracesAreCheckedWhenSearchingForEndOfClass() : void
@@ -139,7 +128,6 @@ namespace phpDocumentor\Reflection\Types {
         }
 
         /**
-         * @covers ::createForNamespace
          * @uses phpDocumentor\Reflection\Types\Context
          */
         public function testTraitContainsClosureWithUseStatement() : void
@@ -167,9 +155,6 @@ namespace phpDocumentor\Reflection\Types {
             $this->assertSame([], $context->getNamespaceAliases());
         }
 
-        /**
-         * @covers ::createFromReflector
-         */
         public function testEmptyFileName() : void
         {
             $fixture = new ContextFactory();
@@ -178,9 +163,6 @@ namespace phpDocumentor\Reflection\Types {
             $this->assertSame([], $context->getNamespaceAliases());
         }
 
-        /**
-         * @covers ::createFromReflector
-         */
         public function testEvalDClass() : void
         {
             eval(<<<PHP

--- a/tests/unit/Types/ContextTest.php
+++ b/tests/unit/Types/ContextTest.php
@@ -15,45 +15,26 @@ namespace phpDocumentor\Reflection\Types;
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\Types\Context
- */
 class ContextTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::getNamespace
-     */
     public function testProvidesANormalizedNamespace(): void
     {
         $fixture = new Context('\My\Space');
         $this->assertSame('My\Space', $fixture->getNamespace());
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::getNamespace
-     */
     public function testInterpretsNamespaceNamedGlobalAsRootNamespace(): void
     {
         $fixture = new Context('global');
         $this->assertSame('', $fixture->getNamespace());
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::getNamespace
-     */
     public function testInterpretsNamespaceNamedDefaultAsRootNamespace(): void
     {
         $fixture = new Context('default');
         $this->assertSame('', $fixture->getNamespace());
     }
 
-    /**
-     * @covers ::__construct
-     * @covers ::getNamespaceAliases
-     */
     public function testProvidesNormalizedNamespaceAliases(): void
     {
         $fixture = new Context('', ['Space' => '\My\Space']);

--- a/tests/unit/Types/IterableTest.php
+++ b/tests/unit/Types/IterableTest.php
@@ -15,13 +15,9 @@ namespace phpDocumentor\Reflection\Types;
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\Types\Iterable_
- */
 class IterableTest extends TestCase
 {
     /**
-     * @covers ::__toString
      * @dataProvider provideIterables
      */
     public function testIterableStringifyCorrectly(Iterable_ $iterable, string $expectedString): void

--- a/tests/unit/Types/NullableTest.php
+++ b/tests/unit/Types/NullableTest.php
@@ -15,15 +15,8 @@ namespace phpDocumentor\Reflection\Types;
 
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\Types\Nullable
- */
 class NullableTest extends TestCase
 {
-    /**
-     * @covers ::__construct
-     * @covers ::getActualType
-     */
     public function testNullableTypeWrapsCorrectly(): void
     {
         $realType = new String_();
@@ -33,9 +26,6 @@ class NullableTest extends TestCase
         $this->assertSame($realType, $nullableString->getActualType());
     }
 
-    /**
-     * @covers ::__toString
-     */
     public function testNullableStringifyCorrectly(): void
     {
         $this->assertSame('?string', (string) new Nullable(new String_()));

--- a/tests/unit/Types/SelfTest.php
+++ b/tests/unit/Types/SelfTest.php
@@ -7,14 +7,8 @@ namespace phpDocumentor\Reflection\Types;
 use phpDocumentor\Reflection\Fqsen;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\Types\Self_
- */
 class SelfTest extends TestCase
 {
-    /**
-     * @covers ::getGenericTypes
-     */
     public function testCreate(): void
     {
         $genericTypes = [
@@ -30,7 +24,6 @@ class SelfTest extends TestCase
 
     /**
      * @dataProvider provideToStringData
-     * @covers ::__toString
      */
     public function testToString(string $expectedResult, Self_ $type): void
     {

--- a/tests/unit/Types/StaticTest.php
+++ b/tests/unit/Types/StaticTest.php
@@ -7,14 +7,8 @@ namespace phpDocumentor\Reflection\Types;
 use phpDocumentor\Reflection\Fqsen;
 use PHPUnit\Framework\TestCase;
 
-/**
- * @coversDefaultClass \phpDocumentor\Reflection\Types\Static_
- */
 class StaticTest extends TestCase
 {
-    /**
-     * @covers ::getGenericTypes
-     */
     public function testCreate(): void
     {
         $genericTypes = [
@@ -30,7 +24,6 @@ class StaticTest extends TestCase
 
     /**
      * @dataProvider provideToStringData
-     * @covers ::__toString
      */
     public function testToString(string $expectedResult, Static_ $type): void
     {


### PR DESCRIPTION
In fact, the `covers` annotations are only needed to speed up the report generation, but the tests are fast enough that there's not much point in using these annotations. Currently, due to their irrelevance, the test coverage report is not generated correctly. I have removed them, and now everything is generated properly.
I have also updated the configuration to the new format.

### Before

<img width="2494" height="418" alt="image" src="https://github.com/user-attachments/assets/426a5da6-613d-4349-a2e1-c94471fc6f07" />

### After

<img width="2496" height="394" alt="image" src="https://github.com/user-attachments/assets/865fb667-a6dd-4355-854d-97cff3d9ca46" />
