### PR TITLE
Space after comma in array

### DIFF
--- a/src/Types/AbstractList.php
+++ b/src/Types/AbstractList.php
@@ -81,7 +81,7 @@ abstract class AbstractList implements Type
         }
 
         if ($this->keyType) {
-            return 'array<' . $this->keyType . ',' . $this->valueType . '>';
+            return 'array<' . $this->keyType . ', ' . $this->valueType . '>';
         }
 
         if ($this->valueType instanceof Compound) {

--- a/src/Types/Iterable_.php
+++ b/src/Types/Iterable_.php
@@ -30,7 +30,7 @@ final class Iterable_ extends AbstractList
         }
 
         if ($this->keyType) {
-            return 'iterable<' . $this->keyType . ',' . $this->valueType . '>';
+            return 'iterable<' . $this->keyType . ', ' . $this->valueType . '>';
         }
 
         return 'iterable<' . $this->valueType . '>';


### PR DESCRIPTION
Is the more common syntax (psalm, phpstan, WP) and also already used in e.g. ArrayShape.php