### PR TITLE
Add support for `non-positive-int`, `non-negative-int`, `non-zero-int`

### DIFF
--- a/src/PseudoTypes/NonNegativeInteger.php
+++ b/src/PseudoTypes/NonNegativeInteger.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\PseudoType;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Integer;
+
+/**
+ * Value Object representing the type 'int'.
+ *
+ * @psalm-immutable
+ */
+final class NonNegativeInteger extends Integer implements PseudoType
+{
+    public function underlyingType(): Type
+    {
+        return new Integer();
+    }
+
+    /**
+     * Returns a rendered output of the Type as it would be used in a DocBlock.
+     */
+    public function __toString(): string
+    {
+        return 'non-negative-int';
+    }
+}

--- a/src/PseudoTypes/NonPositiveInteger.php
+++ b/src/PseudoTypes/NonPositiveInteger.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\PseudoType;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Integer;
+
+/**
+ * Value Object representing the type 'int'.
+ *
+ * @psalm-immutable
+ */
+final class NonPositiveInteger extends Integer implements PseudoType
+{
+    public function underlyingType(): Type
+    {
+        return new Integer();
+    }
+
+    /**
+     * Returns a rendered output of the Type as it would be used in a DocBlock.
+     */
+    public function __toString(): string
+    {
+        return 'non-positive-int';
+    }
+}

--- a/src/PseudoTypes/NonZeroInteger.php
+++ b/src/PseudoTypes/NonZeroInteger.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\PseudoType;
+use phpDocumentor\Reflection\Type;
+use phpDocumentor\Reflection\Types\Integer;
+
+/**
+ * Value Object representing the type 'int'.
+ *
+ * @psalm-immutable
+ */
+final class NonZeroInteger extends Integer implements PseudoType
+{
+    public function underlyingType(): Type
+    {
+        return new Integer();
+    }
+
+    /**
+     * Returns a rendered output of the Type as it would be used in a DocBlock.
+     */
+    public function __toString(): string
+    {
+        return 'non-zero-int';
+    }
+}

--- a/src/TypeResolver.php
+++ b/src/TypeResolver.php
@@ -44,6 +44,9 @@ use phpDocumentor\Reflection\PseudoTypes\NonEmptyArray;
 use phpDocumentor\Reflection\PseudoTypes\NonEmptyList;
 use phpDocumentor\Reflection\PseudoTypes\NonEmptyLowercaseString;
 use phpDocumentor\Reflection\PseudoTypes\NonEmptyString;
+use phpDocumentor\Reflection\PseudoTypes\NonNegativeInteger;
+use phpDocumentor\Reflection\PseudoTypes\NonPositiveInteger;
+use phpDocumentor\Reflection\PseudoTypes\NonZeroInteger;
 use phpDocumentor\Reflection\PseudoTypes\Numeric_;
 use phpDocumentor\Reflection\PseudoTypes\NumericString;
 use phpDocumentor\Reflection\PseudoTypes\ObjectShape;
@@ -147,6 +150,9 @@ final class TypeResolver
         'integer' => Integer::class,
         'positive-int' => PositiveInteger::class,
         'negative-int' => NegativeInteger::class,
+        'non-negative-int' => NonNegativeInteger::class,
+        'non-positive-int' => NonPositiveInteger::class,
+        'non-zero-int' => NonZeroInteger::class,
         'bool' => Boolean::class,
         'boolean' => Boolean::class,
         'real' => Float_::class,

--- a/tests/unit/PseudoTypes/NonNegativeIntegerTest.php
+++ b/tests/unit/PseudoTypes/NonNegativeIntegerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\Types\Integer;
+use PHPUnit\Framework\TestCase;
+
+final class NonNegativeIntegerTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $type = new NonNegativeInteger();
+        $this->assertEquals(new Integer(), $type->underlyingType());
+    }
+
+    public function testToString(): void
+    {
+        $this->assertSame('non-negative-int', (string) (new NonNegativeInteger()));
+    }
+}

--- a/tests/unit/PseudoTypes/NonPositiveIntegerTest.php
+++ b/tests/unit/PseudoTypes/NonPositiveIntegerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\Types\Integer;
+use PHPUnit\Framework\TestCase;
+
+final class NonPositiveIntegerTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $type = new NonPositiveInteger();
+        $this->assertEquals(new Integer(), $type->underlyingType());
+    }
+
+    public function testToString(): void
+    {
+        $this->assertSame('non-positive-int', (string) (new NonPositiveInteger()));
+    }
+}

--- a/tests/unit/PseudoTypes/NonZeroIntegerTest.php
+++ b/tests/unit/PseudoTypes/NonZeroIntegerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of phpDocumentor.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @link      http://phpdoc.org
+ */
+
+namespace phpDocumentor\Reflection\PseudoTypes;
+
+use phpDocumentor\Reflection\Types\Integer;
+use PHPUnit\Framework\TestCase;
+
+final class NonZeroIntegerTest extends TestCase
+{
+    public function testCreate(): void
+    {
+        $type = new NonZeroInteger();
+        $this->assertEquals(new Integer(), $type->underlyingType());
+    }
+
+    public function testToString(): void
+    {
+        $this->assertSame('non-zero-int', (string) (new NonZeroInteger()));
+    }
+}

--- a/tests/unit/TypeResolverTest.php
+++ b/tests/unit/TypeResolverTest.php
@@ -44,6 +44,9 @@ use phpDocumentor\Reflection\PseudoTypes\NonEmptyArray;
 use phpDocumentor\Reflection\PseudoTypes\NonEmptyList;
 use phpDocumentor\Reflection\PseudoTypes\NonEmptyLowercaseString;
 use phpDocumentor\Reflection\PseudoTypes\NonEmptyString;
+use phpDocumentor\Reflection\PseudoTypes\NonNegativeInteger;
+use phpDocumentor\Reflection\PseudoTypes\NonPositiveInteger;
+use phpDocumentor\Reflection\PseudoTypes\NonZeroInteger;
 use phpDocumentor\Reflection\PseudoTypes\Numeric_;
 use phpDocumentor\Reflection\PseudoTypes\NumericString;
 use phpDocumentor\Reflection\PseudoTypes\ObjectShape;
@@ -642,6 +645,9 @@ class TypeResolverTest extends TestCase
             ['integer', Integer::class],
             ['positive-int', PositiveInteger::class],
             ['negative-int', NegativeInteger::class],
+            ['non-positive-int', NonPositiveInteger::class],
+            ['non-negative-int', NonNegativeInteger::class],
+            ['non-zero-int', NonZeroInteger::class],
             ['float', Float_::class],
             ['double', Float_::class],
             ['bool', Boolean::class],


### PR DESCRIPTION
This PR adds support for `non-positive-int`, `non-negative-int`, and `non-zero-int`.

PHPStan supports these integer-range pseudo-types (including `non-zero-int`), while Psalm does not support `non-zero-int`.

References:
- https://phpstan.org/writing-php-code/phpdoc-types#integer-ranges
- https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/#int-range

The code was copied from the existing `positive-int`/`negative-int` pseudo-type handling and slightly adapted for `non-positive-int`, `non-negative-int`, and `non-zero-int` (changing class names and type strings accordingly).
